### PR TITLE
refactor: extract marshalTSLToXML helper, make TSL Id configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ testdata/postgres
 .pid
 
 cover.out
+trustedlist.xml

--- a/pkg/pipeline/additional_edge_test.go
+++ b/pkg/pipeline/additional_edge_test.go
@@ -145,7 +145,7 @@ func TestPublishTSL_InvalidCertPath(t *testing.T) {
 	_, err = PublishTSL(pl, ctx, tmpDir, "/nonexistent/cert.pem", "/some/key.pem")
 	assert.Error(t, err)
 	// The error comes from the signing step, not validation
-	assert.Contains(t, err.Error(), "failed to sign TSL")
+	assert.Contains(t, err.Error(), "failed to sign XML")
 }
 
 // TestPublishTSL_InvalidKeyPath tests PublishTSL with invalid key file path
@@ -179,7 +179,7 @@ func TestPublishTSL_InvalidKeyPath(t *testing.T) {
 	_, err = PublishTSL(pl, ctx, tmpDir, certFile, "/nonexistent/key.pem")
 	assert.Error(t, err)
 	// The error comes from the signing step, not validation
-	assert.Contains(t, err.Error(), "failed to sign TSL")
+	assert.Contains(t, err.Error(), "failed to sign XML")
 }
 
 // TestPublishTSL_PKCS11Signer tests PublishTSL with PKCS#11 signer configuration

--- a/pkg/pipeline/generate_test.go
+++ b/pkg/pipeline/generate_test.go
@@ -213,12 +213,47 @@ sequenceNumber: 1
 
 	// Verify TSLTag and Id attributes are set
 	assert.Equal(t, "http://uri.etsi.org/19612/TSLTag", tsl.StatusList.TSLTagAttr, "TSLTag should be set")
-	assert.Equal(t, "TSL-001", tsl.StatusList.IdAttr, "Id should be set")
+	assert.Equal(t, "TSL-001", tsl.StatusList.IdAttr, "Id should default to TSL-001 for sequenceNumber 1")
 
 	// Verify scheme information
 	assert.NotNil(t, tsl.StatusList.TslSchemeInformation)
 	assert.Equal(t, "http://uri.etsi.org/TrstSvc/TrustedList/TSLType/EUgeneric", tsl.StatusList.TslSchemeInformation.TslTSLType)
 	assert.Equal(t, 1, tsl.StatusList.TslSchemeInformation.TSLVersionIdentifier)
+}
+
+// TestGenerateTSL_CustomId tests that a custom id from scheme.yaml is used
+func TestGenerateTSL_CustomId(t *testing.T) {
+	dir, err := os.MkdirTemp("", "tsl-custom-id-test-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	err = os.MkdirAll(filepath.Join(dir, "providers", "test_provider"), 0755)
+	assert.NoError(t, err)
+
+	schemeYAML := `operatorNames:
+  - language: en
+    value: "Test Operator"
+type: "http://uri.etsi.org/TrstSvc/TrustedList/TSLType/EUgeneric"
+sequenceNumber: 42
+id: "MY-CUSTOM-TSL"
+`
+	err = os.WriteFile(filepath.Join(dir, "scheme.yaml"), []byte(schemeYAML), 0644)
+	assert.NoError(t, err)
+
+	providerYAML := `names:
+  - language: en
+    value: "Test Provider"
+`
+	err = os.WriteFile(filepath.Join(dir, "providers", "test_provider", "provider.yaml"), []byte(providerYAML), 0644)
+	assert.NoError(t, err)
+
+	ctx := NewContext()
+	ctx, err = GenerateTSL(nil, ctx, dir)
+	assert.NoError(t, err)
+
+	tsl, ok := ctx.TSLs.Peek()
+	assert.True(t, ok)
+	assert.Equal(t, "MY-CUSTOM-TSL", tsl.StatusList.IdAttr, "Custom id from scheme.yaml should be used")
 }
 
 // TestPublishTSL_XMLNamespacesAndAttributes verifies the generated XML has correct namespaces and attributes

--- a/pkg/pipeline/generate_test.go
+++ b/pkg/pipeline/generate_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sirosfoundation/g119612/pkg/logging"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -163,4 +164,110 @@ status: "http://test.example.com/status/valid"
 			}
 		})
 	}
+}
+
+// TestGenerateTSL_Success tests successful TSL generation with proper attributes
+func TestGenerateTSL_Success(t *testing.T) {
+	// Create a valid test directory structure
+	dir, err := os.MkdirTemp("", "tsl-success-test-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// Create providers directory
+	err = os.MkdirAll(filepath.Join(dir, "providers", "test_provider"), 0755)
+	assert.NoError(t, err)
+
+	// Write valid scheme.yaml
+	schemeYAML := `operatorNames:
+  - language: en
+    value: "Test Operator"
+  - language: sv
+    value: "Test Operatör"
+type: "http://uri.etsi.org/TrstSvc/TrustedList/TSLType/EUgeneric"
+sequenceNumber: 1
+`
+	err = os.WriteFile(filepath.Join(dir, "scheme.yaml"), []byte(schemeYAML), 0644)
+	assert.NoError(t, err)
+
+	// Write valid provider.yaml
+	providerYAML := `names:
+  - language: en
+    value: "Test Provider Inc"
+`
+	err = os.WriteFile(filepath.Join(dir, "providers", "test_provider", "provider.yaml"), []byte(providerYAML), 0644)
+	assert.NoError(t, err)
+
+	// Run the GenerateTSL step
+	ctx := NewContext()
+	ctx, err = GenerateTSL(nil, ctx, dir)
+	assert.NoError(t, err)
+
+	// Verify the TSL was created
+	assert.NotNil(t, ctx.TSLs)
+	assert.False(t, ctx.TSLs.IsEmpty())
+
+	// Get the generated TSL
+	tsl, ok := ctx.TSLs.Peek()
+	assert.True(t, ok, "Should be able to peek TSL from stack")
+	assert.NotNil(t, tsl)
+
+	// Verify TSLTag and Id attributes are set
+	assert.Equal(t, "http://uri.etsi.org/19612/TSLTag", tsl.StatusList.TSLTagAttr, "TSLTag should be set")
+	assert.Equal(t, "TSL-001", tsl.StatusList.IdAttr, "Id should be set")
+
+	// Verify scheme information
+	assert.NotNil(t, tsl.StatusList.TslSchemeInformation)
+	assert.Equal(t, "http://uri.etsi.org/TrstSvc/TrustedList/TSLType/EUgeneric", tsl.StatusList.TslSchemeInformation.TslTSLType)
+	assert.Equal(t, 1, tsl.StatusList.TslSchemeInformation.TSLVersionIdentifier)
+}
+
+// TestPublishTSL_XMLNamespacesAndAttributes verifies the generated XML has correct namespaces and attributes
+func TestPublishTSL_XMLNamespacesAndAttributes(t *testing.T) {
+	// Create a temporary output directory
+	outputDir, err := os.MkdirTemp("", "tsl-publish-test-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	// Create a TSL with TSLTag and Id attributes
+	tsl := generateTSL("Test Service", "http://uri.etsi.org/TrstSvc/Svctype/CA/QC", []string{TestCertBase64})
+	tsl.StatusList.TSLTagAttr = "http://uri.etsi.org/19612/TSLTag"
+	tsl.StatusList.IdAttr = "TSL-TEST-001"
+
+	// Set up context
+	ctx := &Context{}
+	ctx.EnsureTSLStack().TSLs.Push(tsl)
+
+	// Run publish
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+	_, err = PublishTSL(pl, ctx, outputDir)
+	assert.NoError(t, err)
+
+	// Read the generated XML
+	content, err := os.ReadFile(filepath.Join(outputDir, "tsl-0.xml"))
+	assert.NoError(t, err)
+	xmlStr := string(content)
+
+	// Verify XML declaration
+	assert.Contains(t, xmlStr, `<?xml version="1.0" encoding="UTF-8"?>`, "Should have XML declaration")
+
+	// Verify namespaces
+	assert.Contains(t, xmlStr, `xmlns="http://uri.etsi.org/02231/v2#"`, "Should have default ETSI TSL namespace")
+	assert.Contains(t, xmlStr, `xmlns:ns2="http://www.w3.org/2000/09/xmldsig#"`, "Should have XML-DSIG namespace")
+	assert.Contains(t, xmlStr, `xmlns:ns6="http://uri.etsi.org/01903/v1.4.1#"`, "Should have XAdES namespace")
+
+	// Verify TSLTag attribute
+	assert.Contains(t, xmlStr, `TSLTag="http://uri.etsi.org/19612/TSLTag"`, "Should have TSLTag attribute")
+
+	// Verify Id attribute
+	assert.Contains(t, xmlStr, `Id="TSL-TEST-001"`, "Should have Id attribute")
+
+	// Verify root element structure
+	assert.Contains(t, xmlStr, "<TrustServiceStatusList", "Should have TrustServiceStatusList root element")
+	assert.Contains(t, xmlStr, "</TrustServiceStatusList>", "Should have closing TrustServiceStatusList tag")
+
+	// Verify it's well-formed (basic check)
+	assert.Contains(t, xmlStr, "<SchemeInformation>", "Should have SchemeInformation element")
+	assert.Contains(t, xmlStr, "<TrustServiceProviderList>", "Should have TrustServiceProviderList element")
 }

--- a/pkg/pipeline/publish.go
+++ b/pkg/pipeline/publish.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sirosfoundation/g119612/pkg/etsi119612"
 	"github.com/sirosfoundation/g119612/pkg/dsig"
+	"github.com/sirosfoundation/g119612/pkg/etsi119612"
 	"github.com/sirosfoundation/g119612/pkg/logging"
 )
 
@@ -58,12 +58,27 @@ func publishTSLToFile(pl *Pipeline, tsl *etsi119612.TSL, filePath string, signer
 		return fmt.Errorf("cannot publish nil TSL")
 	}
 
-	// Create XML representation with root element
+	// Create XML representation with root element and proper namespaces
 	type TrustStatusListWrapper struct {
-		XMLName xml.Name                       `xml:"TrustServiceStatusList"`
-		List    etsi119612.TrustStatusListType `xml:",innerxml"`
+		XMLName    xml.Name `xml:"TrustServiceStatusList"`
+		Xmlns      string   `xml:"xmlns,attr"`
+		XmlnsDs    string   `xml:"xmlns:ns2,attr"`
+		XmlnsXades string   `xml:"xmlns:ns6,attr"`
+		TSLTag     string   `xml:"TSLTag,attr,omitempty"`
+		ID         string   `xml:"Id,attr,omitempty"`
+		etsi119612.TrustStatusListType
 	}
-	wrapper := TrustStatusListWrapper{List: tsl.StatusList}
+	wrapper := TrustStatusListWrapper{
+		Xmlns:               "http://uri.etsi.org/02231/v2#",
+		XmlnsDs:             "http://www.w3.org/2000/09/xmldsig#",
+		XmlnsXades:          "http://uri.etsi.org/01903/v1.4.1#",
+		TSLTag:              tsl.StatusList.TSLTagAttr,
+		ID:                  tsl.StatusList.IdAttr,
+		TrustStatusListType: tsl.StatusList,
+	}
+	// Clear the embedded attrs to avoid duplication
+	wrapper.TrustStatusListType.TSLTagAttr = ""
+	wrapper.TrustStatusListType.IdAttr = ""
 	xmlData, err := xml.MarshalIndent(wrapper, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal TSL to XML: %w", err)

--- a/pkg/pipeline/publish.go
+++ b/pkg/pipeline/publish.go
@@ -53,14 +53,13 @@ func processTreeForPublishing(pl *Pipeline, ctx *Context, tree *TSLTree, baseDir
 }
 
 // trustStatusListWrapper is the XML wrapper for serializing a TrustStatusListType
-// with proper namespace declarations and root-level attributes.
+// with proper namespace declarations. The TSLTag and Id attributes are carried
+// by the embedded TrustStatusListType and must not be duplicated here.
 type trustStatusListWrapper struct {
 	XMLName    xml.Name `xml:"TrustServiceStatusList"`
 	Xmlns      string   `xml:"xmlns,attr"`
 	XmlnsDs    string   `xml:"xmlns:ns2,attr"`
 	XmlnsXades string   `xml:"xmlns:ns6,attr"`
-	TSLTag     string   `xml:"TSLTag,attr,omitempty"`
-	ID         string   `xml:"Id,attr,omitempty"`
 	etsi119612.TrustStatusListType
 }
 
@@ -74,13 +73,8 @@ func marshalTSLToXML(tsl *etsi119612.TSL) ([]byte, error) {
 		Xmlns:               "http://uri.etsi.org/02231/v2#",
 		XmlnsDs:             "http://www.w3.org/2000/09/xmldsig#",
 		XmlnsXades:          "http://uri.etsi.org/01903/v1.4.1#",
-		TSLTag:              tsl.StatusList.TSLTagAttr,
-		ID:                  tsl.StatusList.IdAttr,
 		TrustStatusListType: tsl.StatusList,
 	}
-	// Clear the embedded attrs to avoid duplication in the output
-	wrapper.TrustStatusListType.TSLTagAttr = ""
-	wrapper.TrustStatusListType.IdAttr = ""
 
 	xmlData, err := xml.MarshalIndent(wrapper, "", "  ")
 	if err != nil {

--- a/pkg/pipeline/publish.go
+++ b/pkg/pipeline/publish.go
@@ -52,23 +52,25 @@ func processTreeForPublishing(pl *Pipeline, ctx *Context, tree *TSLTree, baseDir
 	return processNodeForPublishing(pl, ctx, tree.Root, treeDir, 0, signer)
 }
 
-// publishTSLToFile writes a TSL to a file, optionally signing it
-func publishTSLToFile(pl *Pipeline, tsl *etsi119612.TSL, filePath string, signer dsig.XMLSigner) error {
-	if tsl == nil {
-		return fmt.Errorf("cannot publish nil TSL")
-	}
+// trustStatusListWrapper is the XML wrapper for serializing a TrustStatusListType
+// with proper namespace declarations and root-level attributes.
+type trustStatusListWrapper struct {
+	XMLName    xml.Name `xml:"TrustServiceStatusList"`
+	Xmlns      string   `xml:"xmlns,attr"`
+	XmlnsDs    string   `xml:"xmlns:ns2,attr"`
+	XmlnsXades string   `xml:"xmlns:ns6,attr"`
+	TSLTag     string   `xml:"TSLTag,attr,omitempty"`
+	ID         string   `xml:"Id,attr,omitempty"`
+	etsi119612.TrustStatusListType
+}
 
-	// Create XML representation with root element and proper namespaces
-	type TrustStatusListWrapper struct {
-		XMLName    xml.Name `xml:"TrustServiceStatusList"`
-		Xmlns      string   `xml:"xmlns,attr"`
-		XmlnsDs    string   `xml:"xmlns:ns2,attr"`
-		XmlnsXades string   `xml:"xmlns:ns6,attr"`
-		TSLTag     string   `xml:"TSLTag,attr,omitempty"`
-		ID         string   `xml:"Id,attr,omitempty"`
-		etsi119612.TrustStatusListType
+// marshalTSLToXML serializes a TSL to XML with proper namespace declarations,
+// root-level attributes, and an XML header.
+func marshalTSLToXML(tsl *etsi119612.TSL) ([]byte, error) {
+	if tsl == nil {
+		return nil, fmt.Errorf("cannot marshal nil TSL")
 	}
-	wrapper := TrustStatusListWrapper{
+	wrapper := trustStatusListWrapper{
 		Xmlns:               "http://uri.etsi.org/02231/v2#",
 		XmlnsDs:             "http://www.w3.org/2000/09/xmldsig#",
 		XmlnsXades:          "http://uri.etsi.org/01903/v1.4.1#",
@@ -76,16 +78,28 @@ func publishTSLToFile(pl *Pipeline, tsl *etsi119612.TSL, filePath string, signer
 		ID:                  tsl.StatusList.IdAttr,
 		TrustStatusListType: tsl.StatusList,
 	}
-	// Clear the embedded attrs to avoid duplication
+	// Clear the embedded attrs to avoid duplication in the output
 	wrapper.TrustStatusListType.TSLTagAttr = ""
 	wrapper.TrustStatusListType.IdAttr = ""
+
 	xmlData, err := xml.MarshalIndent(wrapper, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to marshal TSL to XML: %w", err)
+		return nil, fmt.Errorf("failed to marshal TSL to XML: %w", err)
 	}
 
-	// Add XML header
-	xmlData = append([]byte(xml.Header), xmlData...)
+	return append([]byte(xml.Header), xmlData...), nil
+}
+
+// publishTSLToFile writes a TSL to a file, optionally signing it
+func publishTSLToFile(pl *Pipeline, tsl *etsi119612.TSL, filePath string, signer dsig.XMLSigner) error {
+	if tsl == nil {
+		return fmt.Errorf("cannot publish nil TSL")
+	}
+
+	xmlData, err := marshalTSLToXML(tsl)
+	if err != nil {
+		return err
+	}
 
 	// Sign the XML if a signer is provided
 	if signer != nil {

--- a/pkg/pipeline/publish_edge_test.go
+++ b/pkg/pipeline/publish_edge_test.go
@@ -60,7 +60,7 @@ func TestPublishStep_SigningError(t *testing.T) {
 	// Test with invalid certificate path - will fail during signing
 	_, err = PublishTSL(pl, ctx, testDir, "/nonexistent/cert.pem", "/nonexistent/key.pem")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to sign TSL")
+	assert.Contains(t, err.Error(), "failed to sign XML")
 }
 
 // TestPublishStep_DirectoryCreation tests automatic directory creation

--- a/pkg/pipeline/publish_test.go
+++ b/pkg/pipeline/publish_test.go
@@ -66,12 +66,12 @@ func TestPublishStep(t *testing.T) {
 	content1, err := os.ReadFile(expectedFile1)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, content1, "File content should not be empty")
-	assert.Contains(t, string(content1), "<TrustServiceStatusList>", "File should contain XML structure")
+	assert.Contains(t, string(content1), "<TrustServiceStatusList", "File should contain XML structure")
 
 	content2, err := os.ReadFile(expectedFile2)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, content2, "File content should not be empty")
-	assert.Contains(t, string(content2), "<TrustServiceStatusList>", "File should contain XML structure")
+	assert.Contains(t, string(content2), "<TrustServiceStatusList", "File should contain XML structure")
 }
 
 func TestPublishStep_Errors(t *testing.T) {
@@ -116,4 +116,414 @@ func TestPublishStep_Errors(t *testing.T) {
 	fileInfos, err := os.ReadDir(tmpdir)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(fileInfos), "No files should be created for nil TSL")
+}
+
+// TestPublishTSLToFile tests the publishTSLToFile function directly
+func TestPublishTSLToFile(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "test-publish-file-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+
+	tsl := generateTSL("Test Service", "http://test.com/type", []string{TestCertBase64})
+	tsl.StatusList.TSLTagAttr = "http://uri.etsi.org/19612/TSLTag"
+	tsl.StatusList.IdAttr = "TEST-001"
+
+	filePath := filepath.Join(outputDir, "test.xml")
+	err = publishTSLToFile(pl, tsl, filePath, nil)
+	assert.NoError(t, err)
+
+	// Verify file was created
+	content, err := os.ReadFile(filePath)
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), `xmlns="http://uri.etsi.org/02231/v2#"`)
+	assert.Contains(t, string(content), `TSLTag="http://uri.etsi.org/19612/TSLTag"`)
+	assert.Contains(t, string(content), `Id="TEST-001"`)
+}
+
+// TestPublishTSLToFile_NilTSL tests publishing a nil TSL
+func TestPublishTSLToFile_NilTSL(t *testing.T) {
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+
+	err := publishTSLToFile(pl, nil, "/tmp/test.xml", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot publish nil TSL")
+}
+
+// TestProcessTreeForPublishing_NilTree tests processTreeForPublishing with nil tree
+func TestProcessTreeForPublishing_NilTree(t *testing.T) {
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+	ctx := &Context{}
+
+	// Nil tree should return nil error
+	err := processTreeForPublishing(pl, ctx, nil, "/tmp", 0, "territory", nil)
+	assert.NoError(t, err)
+
+	// Tree with nil root should return nil error
+	tree := &TSLTree{Root: nil}
+	err = processTreeForPublishing(pl, ctx, tree, "/tmp", 0, "territory", nil)
+	assert.NoError(t, err)
+}
+
+// TestPublishStep_LegacyStackWithDistributionPoints tests legacy stack publishing
+func TestPublishStep_LegacyStackWithDistributionPoints(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "test-legacy-dp-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	// Create TSL with distribution point
+	tsl := generateTSL("Test Service", "http://test.com/type", []string{TestCertBase64})
+	tsl.StatusList.TslSchemeInformation.TslDistributionPoints = &etsi119612.NonEmptyURIListType{
+		URI: []string{"https://example.com/my-custom-tsl.xml"},
+	}
+
+	ctx := &Context{}
+	ctx.EnsureTSLStack().TSLs.Push(tsl)
+
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+
+	_, err = PublishTSL(pl, ctx, outputDir)
+	assert.NoError(t, err)
+
+	// Verify file was created with distribution point name
+	expectedFile := filepath.Join(outputDir, "my-custom-tsl.xml")
+	_, err = os.Stat(expectedFile)
+	assert.NoError(t, err, "File should be created with distribution point name")
+}
+
+// TestPublishStep_TreeWithIndexFormat tests tree publishing with index format
+func TestPublishStep_TreeWithIndexFormat(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "test-tree-index-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	// Create a TSL
+	tsl := generateTSL("Test Service", "http://test.com/type", []string{TestCertBase64})
+	tsl.StatusList.TslSchemeInformation.TslSchemeTerritory = "SE"
+
+	// Create context with tree
+	ctx := &Context{}
+	tree := FromSlice([]*etsi119612.TSL{tsl})
+	ctx.EnsureTSLTrees()
+	ctx.TSLTrees.Push(tree)
+
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+
+	// Test with index-based tree format
+	_, err = PublishTSL(pl, ctx, outputDir, "tree:index")
+	assert.NoError(t, err)
+
+	// Verify tree-0 directory was created
+	treeDir := filepath.Join(outputDir, "tree-0")
+	info, err := os.Stat(treeDir)
+	assert.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+// TestPublishStep_TreeWithoutTerritory tests tree publishing without territory
+func TestPublishStep_TreeWithoutTerritory(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "test-tree-no-territory-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	// Create a TSL without territory
+	tsl := generateTSL("Test Service", "http://test.com/type", []string{TestCertBase64})
+	tsl.StatusList.TslSchemeInformation.TslSchemeTerritory = ""
+
+	// Create context with tree
+	ctx := &Context{}
+	tree := FromSlice([]*etsi119612.TSL{tsl})
+	ctx.EnsureTSLTrees()
+	ctx.TSLTrees.Push(tree)
+
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+
+	// Test with territory format but no territory - should fall back to index
+	_, err = PublishTSL(pl, ctx, outputDir, "tree:territory")
+	assert.NoError(t, err)
+
+	// Verify tree-0 directory was created (fallback)
+	treeDir := filepath.Join(outputDir, "tree-0")
+	info, err := os.Stat(treeDir)
+	assert.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+// TestPublishStep_TreeFlatMode tests tree publishing without tree format (flat mode)
+func TestPublishStep_TreeFlatMode(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "test-tree-flat-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	// Create a TSL
+	tsl := generateTSL("Test Service", "http://test.com/type", []string{TestCertBase64})
+	tsl.StatusList.TslSchemeInformation.TslSchemeTerritory = "SE"
+
+	// Create context with tree (not legacy stack)
+	ctx := &Context{}
+	tree := FromSlice([]*etsi119612.TSL{tsl})
+	ctx.EnsureTSLTrees()
+	ctx.TSLTrees.Push(tree)
+
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+
+	// Publish without tree format - should use flat mode
+	_, err = PublishTSL(pl, ctx, outputDir)
+	assert.NoError(t, err)
+
+	// Verify files are in the root directory, not in subdirectories
+	files, err := os.ReadDir(outputDir)
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, len(files), 1)
+
+	// Verify no SE subdirectory was created
+	_, err = os.Stat(filepath.Join(outputDir, "SE"))
+	assert.True(t, os.IsNotExist(err), "Should not create territory subdirectory in flat mode")
+}
+
+// TestPublishStep_MultipleTSLsInLegacyStack tests publishing multiple TSLs from legacy stack
+func TestPublishStep_MultipleTSLsInLegacyStack(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "test-multi-tsl-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	// Create multiple TSLs
+	tsl1 := generateTSL("Service 1", "http://test.com/type", []string{TestCertBase64})
+	tsl2 := generateTSL("Service 2", "http://test.com/type", []string{TestCertBase64})
+	tsl3 := generateTSL("Service 3", "http://test.com/type", []string{TestCertBase64})
+
+	ctx := &Context{}
+	ctx.EnsureTSLStack().TSLs.Push(tsl1)
+	ctx.EnsureTSLStack().TSLs.Push(tsl2)
+	ctx.EnsureTSLStack().TSLs.Push(tsl3)
+
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+
+	_, err = PublishTSL(pl, ctx, outputDir)
+	assert.NoError(t, err)
+
+	// Verify 3 files were created
+	files, err := os.ReadDir(outputDir)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(files), "Should create 3 files for 3 TSLs")
+}
+
+// TestPublishStep_EmptyDistributionPointURI tests handling of empty distribution point URI
+func TestPublishStep_EmptyDistributionPointURI(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "test-empty-dp-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	// Create TSL with empty distribution point URI
+	tsl := generateTSL("Test Service", "http://test.com/type", []string{TestCertBase64})
+	tsl.StatusList.TslSchemeInformation.TslDistributionPoints = &etsi119612.NonEmptyURIListType{
+		URI: []string{""},
+	}
+
+	ctx := &Context{}
+	ctx.EnsureTSLStack().TSLs.Push(tsl)
+
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+
+	_, err = PublishTSL(pl, ctx, outputDir)
+	assert.NoError(t, err)
+
+	// Should fall back to default naming
+	files, err := os.ReadDir(outputDir)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(files))
+	assert.Equal(t, "tsl-0.xml", files[0].Name())
+}
+
+// TestPublishStep_InvalidCertificatePath tests validation of certificate path
+func TestPublishStep_InvalidCertificatePath(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "test-invalid-cert-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	ctx := &Context{}
+	tsl := generateTSL("Test Service", "http://test.com/type", []string{TestCertBase64})
+	ctx.EnsureTSLStack().TSLs.Push(tsl)
+
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+
+	// Test with path traversal in certificate path
+	_, err = PublishTSL(pl, ctx, outputDir, "../../../etc/passwd", "/tmp/key.pem")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid certificate path")
+}
+
+// TestPublishStep_InvalidKeyPath tests validation of key path
+func TestPublishStep_InvalidKeyPath(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "test-invalid-key-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	ctx := &Context{}
+	tsl := generateTSL("Test Service", "http://test.com/type", []string{TestCertBase64})
+	ctx.EnsureTSLStack().TSLs.Push(tsl)
+
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+
+	// Test with path traversal in key path
+	_, err = PublishTSL(pl, ctx, outputDir, "/tmp/cert.pem", "../../../etc/passwd")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid key path")
+}
+
+// TestPublishStep_PKCS11Signer tests PKCS11 signer configuration
+func TestPublishStep_PKCS11Signer(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "test-pkcs11-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	ctx := &Context{}
+	ctx.Data = make(map[string]interface{})
+	ctx.Data["test"] = "pkcs11"
+	tsl := generateTSL("Test Service", "http://test.com/type", []string{TestCertBase64})
+	ctx.EnsureTSLStack().TSLs.Push(tsl)
+
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+
+	// Test with PKCS11 configuration - will fail because no HSM available
+	// but exercises the PKCS11 config parsing code path
+	_, err = PublishTSL(pl, ctx, outputDir, "pkcs11:module=/usr/lib/softhsm/libsofthsm2.so;token=test", "key-label", "cert-label", "01")
+	// This will fail because no HSM is available, but it exercises the code path
+	assert.Error(t, err)
+}
+
+// TestPublishStep_PKCS11SignerMinimalArgs tests PKCS11 signer with minimal arguments
+func TestPublishStep_PKCS11SignerMinimalArgs(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "test-pkcs11-minimal-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	ctx := &Context{}
+	ctx.Data = make(map[string]interface{})
+	ctx.Data["test"] = "pkcs11"
+	tsl := generateTSL("Test Service", "http://test.com/type", []string{TestCertBase64})
+	ctx.EnsureTSLStack().TSLs.Push(tsl)
+
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+
+	// Test PKCS11 with only module path - exercises default label handling
+	_, err = PublishTSL(pl, ctx, outputDir, "pkcs11:module=/usr/lib/softhsm/libsofthsm2.so;token=test")
+	assert.Error(t, err) // Will fail due to no HSM, but exercises code path
+}
+
+// TestPublishStep_TreeWithNonTreeArg tests tree publishing with non-tree second argument
+func TestPublishStep_TreeWithNonTreeArg(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "test-non-tree-arg-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	// Create a TSL
+	tsl := generateTSL("Test Service", "http://test.com/type", []string{TestCertBase64})
+	tsl.StatusList.TslSchemeInformation.TslSchemeTerritory = "SE"
+
+	// Create context with tree (not legacy stack)
+	ctx := &Context{}
+	tree := FromSlice([]*etsi119612.TSL{tsl})
+	ctx.EnsureTSLTrees()
+	ctx.TSLTrees.Push(tree)
+
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+
+	// Second argument is not a tree format - should use flat mode
+	_, err = PublishTSL(pl, ctx, outputDir, "some-other-arg")
+	assert.NoError(t, err)
+
+	// Files should be in root directory
+	files, err := os.ReadDir(outputDir)
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, len(files), 1)
+}
+
+// TestPublishStep_TreeEmptyFormat tests tree publishing with empty tree format
+func TestPublishStep_TreeEmptyFormat(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "test-empty-format-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	// Create a TSL
+	tsl := generateTSL("Test Service", "http://test.com/type", []string{TestCertBase64})
+	tsl.StatusList.TslSchemeInformation.TslSchemeTerritory = "SE"
+
+	// Create context with tree
+	ctx := &Context{}
+	tree := FromSlice([]*etsi119612.TSL{tsl})
+	ctx.EnsureTSLTrees()
+	ctx.TSLTrees.Push(tree)
+
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+
+	// Empty format after tree: should default to territory
+	_, err = PublishTSL(pl, ctx, outputDir, "tree:")
+	assert.NoError(t, err)
+
+	// SE directory should be created (default is territory)
+	info, err := os.Stat(filepath.Join(outputDir, "SE"))
+	assert.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+// TestPublishStep_TreeInvalidFormat tests tree publishing with invalid tree format
+func TestPublishStep_TreeInvalidFormat(t *testing.T) {
+	outputDir, err := os.MkdirTemp("", "test-invalid-format-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	// Create a TSL
+	tsl := generateTSL("Test Service", "http://test.com/type", []string{TestCertBase64})
+	tsl.StatusList.TslSchemeInformation.TslSchemeTerritory = "SE"
+
+	// Create context with tree
+	ctx := &Context{}
+	tree := FromSlice([]*etsi119612.TSL{tsl})
+	ctx.EnsureTSLTrees()
+	ctx.TSLTrees.Push(tree)
+
+	pl := &Pipeline{
+		Logger: logging.NewLogger(logging.DebugLevel),
+	}
+
+	// Invalid format should default to territory
+	_, err = PublishTSL(pl, ctx, outputDir, "tree:invalid-format")
+	assert.NoError(t, err)
+
+	// SE directory should be created (default is territory)
+	info, err := os.Stat(filepath.Join(outputDir, "SE"))
+	assert.NoError(t, err)
+	assert.True(t, info.IsDir())
 }

--- a/pkg/pipeline/step_generate.go
+++ b/pkg/pipeline/step_generate.go
@@ -53,6 +53,17 @@ type SchemeMetadata struct {
 	OperatorNames  []MultiLangName `yaml:"operatorNames"`            // At least one name required
 	Type           string          `yaml:"type"`                     // URI identifying the TSL type
 	SequenceNumber int             `yaml:"sequenceNumber,omitempty"` // TSL sequence number
+	Id             string          `yaml:"id,omitempty"`             // Optional TSL Id attribute
+}
+
+// TslId returns the TSL Id attribute value.
+// If an explicit Id is set in the metadata, it is returned as-is.
+// Otherwise a default is derived from the sequence number (e.g. "TSL-001").
+func (m *SchemeMetadata) TslId() string {
+	if m.Id != "" {
+		return m.Id
+	}
+	return fmt.Sprintf("TSL-%03d", m.SequenceNumber)
 }
 
 // loadSchemeMetadata loads and parses the scheme metadata from the scheme.yaml file.
@@ -383,7 +394,7 @@ func GenerateTSL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 	tsl := &etsi119612.TSL{
 		StatusList: etsi119612.TrustStatusListType{
 			TSLTagAttr: "http://uri.etsi.org/19612/TSLTag",
-			IdAttr:     "TSL-001",
+			IdAttr:     schemeMetadata.TslId(),
 			TslSchemeInformation: &etsi119612.TSLSchemeInformationType{
 				TSLVersionIdentifier: int(schemeMetadata.SequenceNumber),
 				TslTSLType:           schemeMetadata.Type,

--- a/pkg/pipeline/step_generate.go
+++ b/pkg/pipeline/step_generate.go
@@ -109,6 +109,11 @@ func loadSchemeMetadata(rootDir string) (*SchemeMetadata, error) {
 		return nil, fmt.Errorf("scheme metadata must include a type URI")
 	}
 
+	// Default sequenceNumber to 1 when omitted (zero value)
+	if metadata.SequenceNumber <= 0 {
+		metadata.SequenceNumber = 1
+	}
+
 	return &metadata, nil
 }
 

--- a/pkg/pipeline/step_generate.go
+++ b/pkg/pipeline/step_generate.go
@@ -382,6 +382,8 @@ func GenerateTSL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 
 	tsl := &etsi119612.TSL{
 		StatusList: etsi119612.TrustStatusListType{
+			TSLTagAttr: "http://uri.etsi.org/19612/TSLTag",
+			IdAttr:     "TSL-001",
 			TslSchemeInformation: &etsi119612.TSLSchemeInformationType{
 				TSLVersionIdentifier: int(schemeMetadata.SequenceNumber),
 				TslTSLType:           schemeMetadata.Type,

--- a/pkg/pipeline/step_publish.go
+++ b/pkg/pipeline/step_publish.go
@@ -1,7 +1,6 @@
 package pipeline
 
 import (
-	"encoding/xml"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -136,51 +135,9 @@ func PublishTSL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 			// Construct the full file path
 			filePath := filepath.Join(dirPath, filename)
 
-			// Create XML representation with root element and proper namespaces
-			type TrustStatusListWrapper struct {
-				XMLName    xml.Name `xml:"TrustServiceStatusList"`
-				Xmlns      string   `xml:"xmlns,attr"`
-				XmlnsDs    string   `xml:"xmlns:ns2,attr"`
-				XmlnsXades string   `xml:"xmlns:ns6,attr"`
-				TSLTag     string   `xml:"TSLTag,attr,omitempty"`
-				ID         string   `xml:"Id,attr,omitempty"`
-				etsi119612.TrustStatusListType
+			if err := publishTSLToFile(pl, tsl, filePath, signer); err != nil {
+				return ctx, err
 			}
-			wrapper := TrustStatusListWrapper{
-				Xmlns:               "http://uri.etsi.org/02231/v2#",
-				XmlnsDs:             "http://www.w3.org/2000/09/xmldsig#",
-				XmlnsXades:          "http://uri.etsi.org/01903/v1.4.1#",
-				TSLTag:              tsl.StatusList.TSLTagAttr,
-				ID:                  tsl.StatusList.IdAttr,
-				TrustStatusListType: tsl.StatusList,
-			}
-			// Clear the embedded attrs to avoid duplication
-			wrapper.TrustStatusListType.TSLTagAttr = ""
-			wrapper.TrustStatusListType.IdAttr = ""
-			xmlContent, err := xml.MarshalIndent(wrapper, "", "  ")
-			if err != nil {
-				return ctx, fmt.Errorf("failed to marshal TSL to XML: %w", err)
-			}
-
-			// Add XML header
-			xmlContent = append([]byte(xml.Header), xmlContent...)
-
-			if signer != nil {
-				xmlContent, err = signer.Sign(xmlContent)
-				if err != nil {
-					return ctx, fmt.Errorf("failed to sign TSL: %w", err)
-				}
-			}
-
-			// Write the TSL to file
-			if err := os.WriteFile(filePath, xmlContent, 0644); err != nil {
-				return ctx, fmt.Errorf("failed to write TSL to %s: %w", filePath, err)
-			}
-
-			pl.Logger.Info("Published TSL",
-				logging.F("file", filePath),
-				logging.F("signed", signer != nil),
-				logging.F("size", len(xmlContent)))
 		}
 
 		return ctx, nil
@@ -323,47 +280,9 @@ func PublishTSL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 				logging.F("index", i),
 				logging.F("filename", filename))
 
-			// Create XML representation with root element and proper namespaces
-			type TrustStatusListWrapper struct {
-				XMLName    xml.Name `xml:"TrustServiceStatusList"`
-				Xmlns      string   `xml:"xmlns,attr"`
-				XmlnsDs    string   `xml:"xmlns:ns2,attr"`
-				XmlnsXades string   `xml:"xmlns:ns6,attr"`
-				TSLTag     string   `xml:"TSLTag,attr,omitempty"`
-				ID         string   `xml:"Id,attr,omitempty"`
-				etsi119612.TrustStatusListType
-			}
-			wrapper := TrustStatusListWrapper{
-				Xmlns:               "http://uri.etsi.org/02231/v2#",
-				XmlnsDs:             "http://www.w3.org/2000/09/xmldsig#",
-				XmlnsXades:          "http://uri.etsi.org/01903/v1.4.1#",
-				TSLTag:              tsl.StatusList.TSLTagAttr,
-				ID:                  tsl.StatusList.IdAttr,
-				TrustStatusListType: tsl.StatusList,
-			}
-			// Clear the embedded attrs to avoid duplication
-			wrapper.TrustStatusListType.TSLTagAttr = ""
-			wrapper.TrustStatusListType.IdAttr = ""
-			xmlData, err := xml.MarshalIndent(wrapper, "", "  ")
-			if err != nil {
-				return ctx, fmt.Errorf("failed to marshal TSL to XML: %w", err)
-			}
-
-			// Add XML header
-			xmlData = append([]byte(xml.Header), xmlData...)
-
-			// Sign the XML if a signer is provided
-			if signer != nil {
-				xmlData, err = signer.Sign(xmlData)
-				if err != nil {
-					return ctx, fmt.Errorf("failed to sign XML: %w", err)
-				}
-			}
-
-			// Write to file
 			filePath := filepath.Join(dirPath, filename)
-			if err := os.WriteFile(filePath, xmlData, 0644); err != nil {
-				return ctx, fmt.Errorf("failed to write TSL to file %s: %w", filePath, err)
+			if err := publishTSLToFile(pl, tsl, filePath, signer); err != nil {
+				return ctx, err
 			}
 		}
 	}

--- a/pkg/pipeline/step_publish.go
+++ b/pkg/pipeline/step_publish.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sirosfoundation/g119612/pkg/etsi119612"
 	"github.com/sirosfoundation/g119612/pkg/dsig"
+	"github.com/sirosfoundation/g119612/pkg/etsi119612"
 	"github.com/sirosfoundation/g119612/pkg/logging"
 	"github.com/sirosfoundation/g119612/pkg/validation"
 )
@@ -136,12 +136,27 @@ func PublishTSL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 			// Construct the full file path
 			filePath := filepath.Join(dirPath, filename)
 
-			// Create XML representation with root element
+			// Create XML representation with root element and proper namespaces
 			type TrustStatusListWrapper struct {
-				XMLName xml.Name                       `xml:"TrustServiceStatusList"`
-				List    etsi119612.TrustStatusListType `xml:",innerxml"`
+				XMLName    xml.Name `xml:"TrustServiceStatusList"`
+				Xmlns      string   `xml:"xmlns,attr"`
+				XmlnsDs    string   `xml:"xmlns:ns2,attr"`
+				XmlnsXades string   `xml:"xmlns:ns6,attr"`
+				TSLTag     string   `xml:"TSLTag,attr,omitempty"`
+				ID         string   `xml:"Id,attr,omitempty"`
+				etsi119612.TrustStatusListType
 			}
-			wrapper := TrustStatusListWrapper{List: tsl.StatusList}
+			wrapper := TrustStatusListWrapper{
+				Xmlns:               "http://uri.etsi.org/02231/v2#",
+				XmlnsDs:             "http://www.w3.org/2000/09/xmldsig#",
+				XmlnsXades:          "http://uri.etsi.org/01903/v1.4.1#",
+				TSLTag:              tsl.StatusList.TSLTagAttr,
+				ID:                  tsl.StatusList.IdAttr,
+				TrustStatusListType: tsl.StatusList,
+			}
+			// Clear the embedded attrs to avoid duplication
+			wrapper.TrustStatusListType.TSLTagAttr = ""
+			wrapper.TrustStatusListType.IdAttr = ""
 			xmlContent, err := xml.MarshalIndent(wrapper, "", "  ")
 			if err != nil {
 				return ctx, fmt.Errorf("failed to marshal TSL to XML: %w", err)
@@ -308,12 +323,27 @@ func PublishTSL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 				logging.F("index", i),
 				logging.F("filename", filename))
 
-			// Create XML representation with root element
+			// Create XML representation with root element and proper namespaces
 			type TrustStatusListWrapper struct {
-				XMLName xml.Name                       `xml:"TrustServiceStatusList"`
-				List    etsi119612.TrustStatusListType `xml:",innerxml"`
+				XMLName    xml.Name `xml:"TrustServiceStatusList"`
+				Xmlns      string   `xml:"xmlns,attr"`
+				XmlnsDs    string   `xml:"xmlns:ns2,attr"`
+				XmlnsXades string   `xml:"xmlns:ns6,attr"`
+				TSLTag     string   `xml:"TSLTag,attr,omitempty"`
+				ID         string   `xml:"Id,attr,omitempty"`
+				etsi119612.TrustStatusListType
 			}
-			wrapper := TrustStatusListWrapper{List: tsl.StatusList}
+			wrapper := TrustStatusListWrapper{
+				Xmlns:               "http://uri.etsi.org/02231/v2#",
+				XmlnsDs:             "http://www.w3.org/2000/09/xmldsig#",
+				XmlnsXades:          "http://uri.etsi.org/01903/v1.4.1#",
+				TSLTag:              tsl.StatusList.TSLTagAttr,
+				ID:                  tsl.StatusList.IdAttr,
+				TrustStatusListType: tsl.StatusList,
+			}
+			// Clear the embedded attrs to avoid duplication
+			wrapper.TrustStatusListType.TSLTagAttr = ""
+			wrapper.TrustStatusListType.IdAttr = ""
 			xmlData, err := xml.MarshalIndent(wrapper, "", "  ")
 			if err != nil {
 				return ctx, fmt.Errorf("failed to marshal TSL to XML: %w", err)


### PR DESCRIPTION
Follow-up to #13 — addresses code quality concerns from the review.

## Changes

### 1. Eliminate XML wrapper duplication
The `TrustStatusListWrapper` struct and its population logic were copy-pasted 4 times across `publish.go` and `step_publish.go`. This PR extracts:
- A package-level `trustStatusListWrapper` struct
- A shared `marshalTSLToXML(tsl)` function that handles namespace declarations, attribute promotion, and XML header generation
- Both legacy-stack and flat-mode publish paths in `step_publish.go` now call `publishTSLToFile()` instead of inlining the same marshal/sign/write logic

**Net result: -21 lines** (88 added, 109 removed across 6 files).

### 2. Make TSL Id configurable
The `Id` attribute was hardcoded to `"TSL-001"` for every generated TSL. Now:
- `SchemeMetadata` accepts an optional `id` field in `scheme.yaml`
- When not specified, the Id is derived from the sequence number: `TSL-NNN` (e.g. sequence 1 → `TSL-001`, sequence 42 → `TSL-042`)
- New `TestGenerateTSL_CustomId` test verifies the override

### 3. Test alignment
Updated 3 edge-test assertions that checked for the old inline error string (`"failed to sign TSL"`) to match the refactored message (`"failed to sign XML"`).

---
Includes changes from #13 (fix XML generation schema).