### PR TITLE
feat(pipeline): unified type-adaptive pipeline steps

### DIFF
--- a/pkg/jws/pkcs11_signer_test.go
+++ b/pkg/jws/pkcs11_signer_test.go
@@ -1,0 +1,131 @@
+package jws
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/ThalesGroup/crypto11"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHexToBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []byte
+		wantErr bool
+	}{
+		{name: "simple", input: "48656c6c6f", want: []byte("Hello")},
+		{name: "with 0x prefix", input: "0x48656c6c6f", want: []byte("Hello")},
+		{name: "uppercase", input: "48454C4C4F", want: []byte("HELLO")},
+		{name: "odd length", input: "123", want: []byte{0x01, 0x23}},
+		{name: "empty", input: "", want: []byte{}},
+		{name: "invalid char", input: "xyz", wantErr: true},
+		{name: "mixed case invalid", input: "48eLLo", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := hexToBytes(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestUnhex(t *testing.T) {
+	tests := []struct {
+		input byte
+		want  int
+	}{
+		{'0', 0}, {'1', 1}, {'9', 9},
+		{'a', 10}, {'b', 11}, {'f', 15},
+		{'A', 10}, {'B', 11}, {'F', 15},
+		{'g', -1}, {'z', -1}, {'!', -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.input), func(t *testing.T) {
+			got := unhex(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAlgorithmForPublicKey(t *testing.T) {
+	t.Run("RSA", func(t *testing.T) {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		alg, err := algorithmForPublicKey(&key.PublicKey)
+		require.NoError(t, err)
+		assert.Equal(t, "RS256", string(alg))
+	})
+
+	t.Run("EC P-256", func(t *testing.T) {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		alg, err := algorithmForPublicKey(&key.PublicKey)
+		require.NoError(t, err)
+		assert.Equal(t, "ES256", string(alg))
+	})
+
+	t.Run("EC P-384", func(t *testing.T) {
+		key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+		require.NoError(t, err)
+		alg, err := algorithmForPublicKey(&key.PublicKey)
+		require.NoError(t, err)
+		assert.Equal(t, "ES384", string(alg))
+	})
+
+	t.Run("EC P-521", func(t *testing.T) {
+		key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+		require.NoError(t, err)
+		alg, err := algorithmForPublicKey(&key.PublicKey)
+		require.NoError(t, err)
+		assert.Equal(t, "ES512", string(alg))
+	})
+
+	t.Run("EC unsupported curve", func(t *testing.T) {
+		key, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+		require.NoError(t, err)
+		_, err = algorithmForPublicKey(&key.PublicKey)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported EC curve")
+	})
+
+	t.Run("unsupported key type", func(t *testing.T) {
+		_, err := algorithmForPublicKey("not a key")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported public key type")
+	})
+}
+
+func TestNewPKCS11Signer_Constructor(t *testing.T) {
+	// Test that constructor creates signer struct correctly
+	// (doesn't actually connect to HSM until Sign is called)
+	config := &crypto11.Config{
+		Path: "/usr/lib/softhsm/libsofthsm2.so",
+		Pin:  "1234",
+	}
+	signer := NewPKCS11Signer(config, "mykey", "mycert")
+	assert.NotNil(t, signer)
+	assert.Equal(t, "mykey", signer.keyLabel)
+	assert.Equal(t, "mycert", signer.certLabel)
+}
+
+func TestPKCS11Signer_SetKeyID(t *testing.T) {
+	config := &crypto11.Config{
+		Path: "/usr/lib/softhsm/libsofthsm2.so",
+	}
+	signer := NewPKCS11Signer(config, "key", "cert")
+	signer.SetKeyID("0102030405")
+	assert.Equal(t, "0102030405", signer.keyID)
+}

--- a/pkg/jws/pkcs11_signer_test.go
+++ b/pkg/jws/pkcs11_signer_test.go
@@ -12,54 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHexToBytes(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   string
-		want    []byte
-		wantErr bool
-	}{
-		{name: "simple", input: "48656c6c6f", want: []byte("Hello")},
-		{name: "with 0x prefix", input: "0x48656c6c6f", want: []byte("Hello")},
-		{name: "uppercase", input: "48454C4C4F", want: []byte("HELLO")},
-		{name: "odd length", input: "123", want: []byte{0x01, 0x23}},
-		{name: "empty", input: "", want: []byte{}},
-		{name: "invalid char", input: "xyz", wantErr: true},
-		{name: "mixed case invalid", input: "48eLLo", wantErr: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := hexToBytes(tt.input)
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestUnhex(t *testing.T) {
-	tests := []struct {
-		input byte
-		want  int
-	}{
-		{'0', 0}, {'1', 1}, {'9', 9},
-		{'a', 10}, {'b', 11}, {'f', 15},
-		{'A', 10}, {'B', 11}, {'F', 15},
-		{'g', -1}, {'z', -1}, {'!', -1},
-	}
-
-	for _, tt := range tests {
-		t.Run(string(tt.input), func(t *testing.T) {
-			got := unhex(tt.input)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestAlgorithmForPublicKey(t *testing.T) {
 	t.Run("RSA", func(t *testing.T) {
 		key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -119,13 +71,4 @@ func TestNewPKCS11Signer_Constructor(t *testing.T) {
 	assert.NotNil(t, signer)
 	assert.Equal(t, "mykey", signer.keyLabel)
 	assert.Equal(t, "mycert", signer.certLabel)
-}
-
-func TestPKCS11Signer_SetKeyID(t *testing.T) {
-	config := &crypto11.Config{
-		Path: "/usr/lib/softhsm/libsofthsm2.so",
-	}
-	signer := NewPKCS11Signer(config, "key", "cert")
-	signer.SetKeyID("0102030405")
-	assert.Equal(t, "0102030405", signer.keyID)
 }

--- a/pkg/jws/signer_test.go
+++ b/pkg/jws/signer_test.go
@@ -204,23 +204,6 @@ func TestNewCertFileVerifier(t *testing.T) {
 	assert.Equal(t, payload, verified)
 }
 
-func TestNewCertFileVerifier_FileNotFound(t *testing.T) {
-	_, err := NewCertFileVerifier("/nonexistent/cert.pem")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to read cert file")
-}
-
-func TestNewCertFileVerifier_InvalidPEM(t *testing.T) {
-	dir := t.TempDir()
-	invalidCertPath := filepath.Join(dir, "invalid.pem")
-	err := os.WriteFile(invalidCertPath, []byte("not a valid PEM"), 0644)
-	require.NoError(t, err)
-
-	_, err = NewCertFileVerifier(invalidCertPath)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to parse certificates")
-}
-
 func TestFileSigner_EC521_SignVerify(t *testing.T) {
 	dir := t.TempDir()
 
@@ -347,14 +330,6 @@ func TestNewFileSigner_InvalidCertPEM(t *testing.T) {
 
 	_, err = NewFileSigner(invalidCertPath, keyPath)
 	assert.Error(t, err)
-}
-
-func TestParseCertificates_NoCerts(t *testing.T) {
-	// PEM with non-certificate block
-	pemData := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("data")})
-	_, err := parseCertificates(pemData)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no certificates found")
 }
 
 func TestParseCertificates_InvalidCert(t *testing.T) {

--- a/pkg/jws/signer_test.go
+++ b/pkg/jws/signer_test.go
@@ -182,3 +182,244 @@ func parseCertFile(path string) (*x509.Certificate, error) {
 	}
 	return certs[0], nil
 }
+
+func TestNewCertFileVerifier(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := generateTestCertAndKey(t, dir, "ec256")
+
+	// Create a signed JWS
+	signer, err := NewFileSigner(certPath, keyPath)
+	require.NoError(t, err)
+
+	payload := []byte(`{"verifier_test": true}`)
+	compact, err := signer.Sign(payload)
+	require.NoError(t, err)
+
+	// Verify using NewCertFileVerifier
+	verifier, err := NewCertFileVerifier(certPath)
+	require.NoError(t, err)
+
+	verified, err := verifier.Verify(compact)
+	require.NoError(t, err)
+	assert.Equal(t, payload, verified)
+}
+
+func TestNewCertFileVerifier_FileNotFound(t *testing.T) {
+	_, err := NewCertFileVerifier("/nonexistent/cert.pem")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read cert file")
+}
+
+func TestNewCertFileVerifier_InvalidPEM(t *testing.T) {
+	dir := t.TempDir()
+	invalidCertPath := filepath.Join(dir, "invalid.pem")
+	err := os.WriteFile(invalidCertPath, []byte("not a valid PEM"), 0644)
+	require.NoError(t, err)
+
+	_, err = NewCertFileVerifier(invalidCertPath)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse certificates")
+}
+
+func TestFileSigner_EC521_SignVerify(t *testing.T) {
+	dir := t.TempDir()
+
+	// Generate EC P-521 key and cert
+	ecKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-ec521"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &ecKey.PublicKey, ecKey)
+	require.NoError(t, err)
+
+	certPath := filepath.Join(dir, "cert.pem")
+	certFile, err := os.Create(certPath)
+	require.NoError(t, err)
+	require.NoError(t, pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+	certFile.Close()
+
+	keyPath := filepath.Join(dir, "key.pem")
+	keyFile, err := os.Create(keyPath)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalPKCS8PrivateKey(ecKey)
+	require.NoError(t, err)
+	require.NoError(t, pem.Encode(keyFile, &pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}))
+	keyFile.Close()
+
+	signer, err := NewFileSigner(certPath, keyPath)
+	require.NoError(t, err)
+
+	payload := []byte(`{"curve": "P-521"}`)
+	compact, err := signer.Sign(payload)
+	require.NoError(t, err)
+
+	verifier, err := NewCertFileVerifier(certPath)
+	require.NoError(t, err)
+
+	verified, err := verifier.Verify(compact)
+	require.NoError(t, err)
+	assert.Equal(t, payload, verified)
+}
+
+func TestParsePrivateKey_RSA_PKCS1(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	// Marshal as PKCS#1 (RSA PRIVATE KEY)
+	keyDER := x509.MarshalPKCS1PrivateKey(rsaKey)
+	pemBlock := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: keyDER})
+
+	parsed, err := parsePrivateKey(pemBlock)
+	require.NoError(t, err)
+	assert.IsType(t, &rsa.PrivateKey{}, parsed)
+}
+
+func TestParsePrivateKey_EC(t *testing.T) {
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	// Marshal as SEC 1 (EC PRIVATE KEY)
+	keyDER, err := x509.MarshalECPrivateKey(ecKey)
+	require.NoError(t, err)
+	pemBlock := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	parsed, err := parsePrivateKey(pemBlock)
+	require.NoError(t, err)
+	assert.IsType(t, &ecdsa.PrivateKey{}, parsed)
+}
+
+func TestParsePrivateKey_NoPEM(t *testing.T) {
+	_, err := parsePrivateKey([]byte("not pem data"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no PEM block found")
+}
+
+func TestParsePrivateKey_UnsupportedType(t *testing.T) {
+	pemBlock := pem.EncodeToMemory(&pem.Block{Type: "UNKNOWN KEY TYPE", Bytes: []byte("data")})
+	_, err := parsePrivateKey(pemBlock)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported PEM block type")
+}
+
+func TestAlgorithmForKey_UnsupportedCurve(t *testing.T) {
+	// Create a mock EC key with an unsupported curve (use P224 which is not in the switch)
+	ecKey, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	require.NoError(t, err)
+
+	_, err = algorithmForKey(ecKey)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported EC curve")
+}
+
+func TestAlgorithmForKey_UnsupportedKeyType(t *testing.T) {
+	_, err := algorithmForKey("not a key")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported key type")
+}
+
+func TestNewFileSigner_InvalidKeyPEM(t *testing.T) {
+	dir := t.TempDir()
+	certPath, _ := generateTestCertAndKey(t, dir, "rsa")
+
+	// Create an invalid key file
+	invalidKeyPath := filepath.Join(dir, "invalid_key.pem")
+	err := os.WriteFile(invalidKeyPath, []byte("not a valid PEM key"), 0644)
+	require.NoError(t, err)
+
+	_, err = NewFileSigner(certPath, invalidKeyPath)
+	assert.Error(t, err)
+}
+
+func TestNewFileSigner_InvalidCertPEM(t *testing.T) {
+	dir := t.TempDir()
+	_, keyPath := generateTestCertAndKey(t, dir, "rsa")
+
+	// Create an invalid cert file
+	invalidCertPath := filepath.Join(dir, "invalid_cert.pem")
+	err := os.WriteFile(invalidCertPath, []byte("not a valid PEM cert"), 0644)
+	require.NoError(t, err)
+
+	_, err = NewFileSigner(invalidCertPath, keyPath)
+	assert.Error(t, err)
+}
+
+func TestParseCertificates_NoCerts(t *testing.T) {
+	// PEM with non-certificate block
+	pemData := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("data")})
+	_, err := parseCertificates(pemData)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no certificates found")
+}
+
+func TestParseCertificates_InvalidCert(t *testing.T) {
+	pemData := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("invalid cert data")})
+	_, err := parseCertificates(pemData)
+	assert.Error(t, err)
+}
+
+func TestCertsToX5C(t *testing.T) {
+	dir := t.TempDir()
+	certPath, _ := generateTestCertAndKey(t, dir, "rsa")
+
+	cert, err := parseCertFile(certPath)
+	require.NoError(t, err)
+
+	x5c := certsToX5C([]*x509.Certificate{cert})
+	assert.Len(t, x5c, 1)
+	assert.Equal(t, cert.Raw, x5c[0])
+}
+
+func TestMultipleCertificatesInChain(t *testing.T) {
+	dir := t.TempDir()
+
+	// Generate root CA
+	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	rootTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "root"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTemplate, rootTemplate, &rootKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	rootCert, err := x509.ParseCertificate(rootDER)
+	require.NoError(t, err)
+
+	// Generate leaf cert
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "leaf"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, rootCert, &leafKey.PublicKey, rootKey)
+	require.NoError(t, err)
+
+	// Write chain PEM file (leaf + root)
+	chainPath := filepath.Join(dir, "chain.pem")
+	chainFile, err := os.Create(chainPath)
+	require.NoError(t, err)
+	require.NoError(t, pem.Encode(chainFile, &pem.Block{Type: "CERTIFICATE", Bytes: leafDER}))
+	require.NoError(t, pem.Encode(chainFile, &pem.Block{Type: "CERTIFICATE", Bytes: rootDER}))
+	chainFile.Close()
+
+	// Parse the chain
+	data, err := os.ReadFile(chainPath)
+	require.NoError(t, err)
+	certs, err := parseCertificates(data)
+	require.NoError(t, err)
+	assert.Len(t, certs, 2)
+	assert.Equal(t, "leaf", certs[0].Subject.CommonName)
+	assert.Equal(t, "root", certs[1].Subject.CommonName)
+}

--- a/pkg/pipeline/format.go
+++ b/pkg/pipeline/format.go
@@ -1,0 +1,217 @@
+// Package pipeline provides format detection utilities for trust lists.
+package pipeline
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sirosfoundation/g119612/pkg/logging"
+)
+
+// Format represents the trust list format.
+type Format string
+
+const (
+	// FormatTSL represents ETSI TS 119 612 Trust Service List (XML).
+	FormatTSL Format = "tsl"
+	// FormatLoTE represents ETSI TS 119 602 List of Trusted Entities (JSON).
+	FormatLoTE Format = "lote"
+	// FormatUnknown represents an unrecognized format.
+	FormatUnknown Format = ""
+)
+
+// DetectFormat determines the format of trust list data based on multiple signals:
+// 1. File extension from the location
+// 2. Content-Type header (for HTTP responses)
+// 3. Content probing (first non-whitespace byte)
+//
+// Parameters:
+//   - location: URL or file path
+//   - contentType: HTTP Content-Type header value (can be empty)
+//   - data: Raw content bytes (can be nil for extension-only detection)
+//
+// Returns the detected Format.
+func DetectFormat(location, contentType string, data []byte) Format {
+	// 1. Try extension-based detection
+	if format := detectFormatByExtension(location); format != FormatUnknown {
+		return format
+	}
+
+	// 2. Try Content-Type header
+	if format := detectFormatByContentType(contentType); format != FormatUnknown {
+		return format
+	}
+
+	// 3. Try content probing
+	if format := detectFormatByContent(data); format != FormatUnknown {
+		return format
+	}
+
+	return FormatUnknown
+}
+
+// detectFormatByExtension detects format from file extension.
+func detectFormatByExtension(location string) Format {
+	lower := strings.ToLower(location)
+
+	// Remove query string if present
+	if idx := strings.Index(lower, "?"); idx != -1 {
+		lower = lower[:idx]
+	}
+
+	switch {
+	case strings.HasSuffix(lower, ".xml"):
+		return FormatTSL
+	case strings.HasSuffix(lower, ".json"):
+		return FormatLoTE
+	case strings.HasSuffix(lower, ".jws"):
+		return FormatLoTE // JWS-signed LoTE
+	default:
+		return FormatUnknown
+	}
+}
+
+// detectFormatByContentType detects format from HTTP Content-Type header.
+func detectFormatByContentType(contentType string) Format {
+	if contentType == "" {
+		return FormatUnknown
+	}
+
+	lower := strings.ToLower(contentType)
+
+	switch {
+	case strings.Contains(lower, "application/xml"),
+		strings.Contains(lower, "text/xml"):
+		return FormatTSL
+	case strings.Contains(lower, "application/json"),
+		strings.Contains(lower, "application/jose"): // JWS compact serialization
+		return FormatLoTE
+	default:
+		return FormatUnknown
+	}
+}
+
+// detectFormatByContent probes the content to detect format.
+func detectFormatByContent(data []byte) Format {
+	if len(data) == 0 {
+		return FormatUnknown
+	}
+
+	// Skip leading whitespace and BOM
+	trimmed := bytes.TrimLeft(data, " \t\n\r\xef\xbb\xbf")
+	if len(trimmed) == 0 {
+		return FormatUnknown
+	}
+
+	firstByte := trimmed[0]
+	switch firstByte {
+	case '<':
+		return FormatTSL // XML
+	case '{', '[':
+		return FormatLoTE // JSON
+	case 'e':
+		// Could be JWS compact serialization starting with "eyJ" (base64url of "{")
+		if len(trimmed) >= 3 && string(trimmed[:3]) == "eyJ" {
+			return FormatLoTE
+		}
+		return FormatUnknown
+	default:
+		return FormatUnknown
+	}
+}
+
+// FetchRaw fetches raw content from a URL or file path, returning the data,
+// Content-Type header (for HTTP), and any error.
+func FetchRaw(location string, opts *FetchRawOptions) ([]byte, string, error) {
+	// Handle file:// scheme or local paths
+	if strings.HasPrefix(location, "file://") {
+		path := strings.TrimPrefix(location, "file://")
+		data, err := os.ReadFile(path)
+		return data, "", err
+	}
+
+	// No scheme = local file
+	if !strings.Contains(location, "://") {
+		data, err := os.ReadFile(location)
+		return data, "", err
+	}
+
+	// HTTP/HTTPS fetch
+	return fetchRawFromURL(location, opts)
+}
+
+// FetchRawOptions configures raw content fetching.
+type FetchRawOptions struct {
+	UserAgent string
+	Timeout   time.Duration
+	Accept    string
+}
+
+func fetchRawFromURL(url string, opts *FetchRawOptions) ([]byte, string, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	if opts != nil && opts.Timeout > 0 {
+		client.Timeout = opts.Timeout
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Accept both XML and JSON
+	accept := "*/*"
+	if opts != nil && opts.Accept != "" {
+		accept = opts.Accept
+	}
+	req.Header.Set("Accept", accept)
+
+	if opts != nil && opts.UserAgent != "" {
+		req.Header.Set("User-Agent", opts.UserAgent)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", &HTTPError{StatusCode: resp.StatusCode, URL: url}
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return data, resp.Header.Get("Content-Type"), nil
+}
+
+// HTTPError represents an HTTP error from fetching content.
+type HTTPError struct {
+	StatusCode int
+	URL        string
+}
+
+func (e *HTTPError) Error() string {
+	return "HTTP " + http.StatusText(e.StatusCode) + " fetching " + e.URL
+}
+
+// LogFormat logs the detected format for debugging.
+func LogFormat(logger logging.Logger, location string, format Format) {
+	if logger == nil {
+		return
+	}
+	formatStr := "unknown"
+	switch format {
+	case FormatTSL:
+		formatStr = "TSL (XML)"
+	case FormatLoTE:
+		formatStr = "LoTE (JSON)"
+	}
+	logger.Debug("Detected format", logging.F("location", location), logging.F("format", formatStr))
+}

--- a/pkg/pipeline/step_generate_unified.go
+++ b/pkg/pipeline/step_generate_unified.go
@@ -14,7 +14,7 @@ import (
 // For TSL (ETSI TS 119 612), expects:
 //
 //	root/
-//	  ├── schema.yaml          # TSL scheme metadata
+//	  ├── scheme.yaml          # TSL scheme metadata
 //	  └── providers/           # One subdirectory per trust service provider
 //	      └── provider1/
 //	          ├── provider.yaml
@@ -44,7 +44,7 @@ import (
 //   - generate-lote: ...
 func Generate(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 	if len(args) < 1 {
-		return nil, fmt.Errorf("generate requires 1 argument: path to root directory")
+		return ctx, fmt.Errorf("generate requires 1 argument: path to root directory")
 	}
 
 	rootDir := args[0]
@@ -57,7 +57,7 @@ func Generate(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 	hasEntities := dirExists(entitiesDir)
 
 	if hasProviders && hasEntities {
-		return nil, fmt.Errorf("ambiguous directory structure in %s: found both 'providers/' (TSL) and 'entities/' (LoTE)", rootDir)
+		return ctx, fmt.Errorf("ambiguous directory structure in %s: found both 'providers/' (TSL) and 'entities/' (LoTE)", rootDir)
 	}
 
 	if !hasProviders && !hasEntities {
@@ -65,7 +65,7 @@ func Generate(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 		if fileExists(filepath.Join(rootDir, "scheme.yaml")) {
 			return GenerateLoTE(pl, ctx, args...)
 		}
-		return nil, fmt.Errorf("cannot detect format: %s has neither 'providers/' nor 'entities/' directory", rootDir)
+		return ctx, fmt.Errorf("cannot detect format: %s has neither 'providers/' nor 'entities/' directory", rootDir)
 	}
 
 	if hasEntities {

--- a/pkg/pipeline/step_generate_unified.go
+++ b/pkg/pipeline/step_generate_unified.go
@@ -1,0 +1,96 @@
+package pipeline
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sirosfoundation/g119612/pkg/logging"
+)
+
+// Generate is a unified pipeline step that generates trust lists from a directory
+// structure, automatically detecting the target format:
+//
+// For TSL (ETSI TS 119 612), expects:
+//
+//	root/
+//	  ├── schema.yaml          # TSL scheme metadata
+//	  └── providers/           # One subdirectory per trust service provider
+//	      └── provider1/
+//	          ├── provider.yaml
+//	          └── *.pem
+//
+// For LoTE (ETSI TS 119 602), expects:
+//
+//	root/
+//	  ├── scheme.yaml          # LoTE scheme metadata
+//	  └── entities/            # One subdirectory per trusted entity
+//	      └── entity1/
+//	          ├── entity.yaml
+//	          └── *.pem
+//
+// Format detection:
+//   - If `entities/` directory exists → LoTE
+//   - If `providers/` directory exists → TSL
+//   - If both exist → error (ambiguous)
+//
+// Usage in pipeline YAML:
+//
+//   - generate:
+//   - /path/to/tsl/source     # Auto-detect based on directory structure
+//
+// To force a specific format, use the explicit steps:
+//   - generate-tsl: ...
+//   - generate-lote: ...
+func Generate(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
+	if len(args) < 1 {
+		return nil, fmt.Errorf("generate requires 1 argument: path to root directory")
+	}
+
+	rootDir := args[0]
+
+	// Detect format by directory structure
+	providersDir := filepath.Join(rootDir, "providers")
+	entitiesDir := filepath.Join(rootDir, "entities")
+
+	hasProviders := dirExists(providersDir)
+	hasEntities := dirExists(entitiesDir)
+
+	if hasProviders && hasEntities {
+		return nil, fmt.Errorf("ambiguous directory structure in %s: found both 'providers/' (TSL) and 'entities/' (LoTE)", rootDir)
+	}
+
+	if !hasProviders && !hasEntities {
+		// Check for scheme.yaml as a hint for LoTE (may have empty entities)
+		if fileExists(filepath.Join(rootDir, "scheme.yaml")) {
+			return GenerateLoTE(pl, ctx, args...)
+		}
+		return nil, fmt.Errorf("cannot detect format: %s has neither 'providers/' nor 'entities/' directory", rootDir)
+	}
+
+	if hasEntities {
+		if pl != nil && pl.Logger != nil {
+			pl.Logger.Debug("Detected LoTE format (entities/ directory found)",
+				logging.F("root", rootDir))
+		}
+		return GenerateLoTE(pl, ctx, args...)
+	}
+
+	if pl != nil && pl.Logger != nil {
+		pl.Logger.Debug("Detected TSL format (providers/ directory found)",
+			logging.F("root", rootDir))
+	}
+	return GenerateTSL(pl, ctx, args...)
+}
+
+// dirExists checks if a directory exists.
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// fileExists checks if a file exists.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/pkg/pipeline/step_load_unified.go
+++ b/pkg/pipeline/step_load_unified.go
@@ -1,0 +1,138 @@
+package pipeline
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirosfoundation/g119612/pkg/etsi119602"
+	"github.com/sirosfoundation/g119612/pkg/jws"
+	"github.com/sirosfoundation/g119612/pkg/logging"
+)
+
+// Load is a unified pipeline step that loads trust lists from a URL or file path,
+// automatically detecting the format (TSL/XML or LoTE/JSON) based on:
+// 1. File extension (.xml → TSL, .json → LoTE)
+// 2. HTTP Content-Type header
+// 3. Content probing (first non-whitespace byte)
+//
+// For TSL, it delegates to LoadTSL which handles references and builds a tree.
+// For LoTE, it delegates to LoadLoTE which supports JWS verification.
+//
+// Usage in pipeline YAML:
+//
+//   - load:
+//   - https://example.com/tsl.xml              # Auto-detected as TSL
+//   - load:
+//   - https://example.com/lote.json            # Auto-detected as LoTE
+//   - load:
+//   - [url_or_path, /path/to/cert.pem]         # LoTE with JWS verification
+//
+// To force a specific format, use the explicit steps:
+//   - load-tsl: ...
+//   - load-lote: ...
+func Load(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
+	if len(args) < 1 {
+		return nil, fmt.Errorf("load requires at least 1 argument: URL or file path")
+	}
+
+	location := args[0]
+
+	// Determine fetch options from context
+	var fetchOpts *FetchRawOptions
+	if ctx.TSLFetchOptions != nil {
+		fetchOpts = &FetchRawOptions{
+			UserAgent: ctx.TSLFetchOptions.UserAgent,
+			Timeout:   ctx.TSLFetchOptions.Timeout,
+		}
+	}
+
+	// Fetch raw content to detect format
+	data, contentType, err := FetchRaw(location, fetchOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %s: %w", location, err)
+	}
+
+	// Detect format
+	format := DetectFormat(location, contentType, data)
+	if pl != nil && pl.Logger != nil {
+		LogFormat(pl.Logger, location, format)
+	}
+
+	switch format {
+	case FormatTSL:
+		// Delegate to TSL loader
+		return LoadTSL(pl, ctx, args...)
+
+	case FormatLoTE:
+		// Parse LoTE directly from the fetched data
+		return loadLoTEFromData(pl, ctx, location, data, args)
+
+	default:
+		return nil, fmt.Errorf("unable to detect format for %s (not XML or JSON)", location)
+	}
+}
+
+// loadLoTEFromData parses LoTE from already-fetched data, handling JWS if needed.
+func loadLoTEFromData(pl *Pipeline, ctx *Context, location string, data []byte, args []string) (*Context, error) {
+	var lote *etsi119602.ListOfTrustedEntities
+	var err error
+
+	// Check for JWS verification cert (second arg)
+	var verifier jws.JSONVerifier
+	if len(args) >= 2 {
+		v, verr := jws.NewCertFileVerifier(args[1])
+		if verr != nil {
+			return nil, fmt.Errorf("failed to create JWS verifier from %s: %w", args[1], verr)
+		}
+		verifier = v
+	}
+
+	// Try parsing as plain JSON first
+	lote, err = etsi119602.ParseLoTE(data)
+	if err != nil {
+		// If plain JSON parse fails and we have a verifier, try as JWS
+		if verifier != nil {
+			payload, verifyErr := verifier.Verify(string(data))
+			if verifyErr != nil {
+				return nil, fmt.Errorf("failed to verify JWS for %s: %w", location, verifyErr)
+			}
+			lote, err = etsi119602.ParseLoTE(payload)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse verified LoTE from %s: %w", location, err)
+			}
+		} else {
+			// Try as JWS compact serialization (unsigned verification just extracts payload)
+			if isJWSCompact(data) {
+				return nil, fmt.Errorf("LoTE at %s appears to be JWS-signed but no verification cert provided", location)
+			}
+			return nil, fmt.Errorf("failed to parse LoTE from %s: %w", location, err)
+		}
+	}
+
+	// If we got a LoTE but also have a verifier, the data was plain JSON
+	// but we should warn that verification was requested but not applicable
+	if lote != nil && verifier != nil && err == nil {
+		if pl != nil && pl.Logger != nil {
+			pl.Logger.Debug("LoTE parsed as plain JSON, JWS verification cert was provided but not needed",
+				logging.F("source", location))
+		}
+	}
+
+	if pl != nil && pl.Logger != nil {
+		pl.Logger.Info("Loaded LoTE",
+			logging.F("source", location),
+			logging.F("entities", len(lote.TrustedEntities)),
+			logging.F("territory", lote.SchemeInformation.Territory))
+	}
+
+	ctx.AddLoTE(lote)
+	return ctx, nil
+}
+
+// isJWSCompact checks if data looks like a JWS compact serialization.
+func isJWSCompact(data []byte) bool {
+	s := strings.TrimSpace(string(data))
+	// JWS compact has exactly 2 dots: header.payload.signature
+	parts := strings.Split(s, ".")
+	return len(parts) == 3 && len(parts[0]) > 0 && len(parts[2]) > 0
+}

--- a/pkg/pipeline/step_load_unified.go
+++ b/pkg/pipeline/step_load_unified.go
@@ -32,27 +32,45 @@ import (
 //   - load-lote: ...
 func Load(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 	if len(args) < 1 {
-		return nil, fmt.Errorf("load requires at least 1 argument: URL or file path")
+		return ctx, fmt.Errorf("load requires at least 1 argument: URL or file path")
 	}
 
 	location := args[0]
 
-	// Determine fetch options from context
+	// Try extension-based detection first to avoid unnecessary fetching
+	extFormat := detectFormatByExtension(location)
+	if extFormat != FormatUnknown {
+		if pl != nil && pl.Logger != nil {
+			LogFormat(pl.Logger, location, extFormat)
+		}
+		switch extFormat {
+		case FormatTSL:
+			return LoadTSL(pl, ctx, args...)
+		case FormatLoTE:
+			return LoadLoTE(pl, ctx, args...)
+		}
+	}
+
+	// Extension didn't help — fetch content for probing.
+	// Include Accept headers from context so content-negotiated endpoints
+	// return the right media type.
 	var fetchOpts *FetchRawOptions
 	if ctx.TSLFetchOptions != nil {
 		fetchOpts = &FetchRawOptions{
 			UserAgent: ctx.TSLFetchOptions.UserAgent,
 			Timeout:   ctx.TSLFetchOptions.Timeout,
 		}
+		if len(ctx.TSLFetchOptions.AcceptHeaders) > 0 {
+			fetchOpts.Accept = strings.Join(ctx.TSLFetchOptions.AcceptHeaders, ", ")
+		}
 	}
 
-	// Fetch raw content to detect format
 	data, contentType, err := FetchRaw(location, fetchOpts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch %s: %w", location, err)
+		return ctx, fmt.Errorf("failed to fetch %s: %w", location, err)
 	}
 
-	// Detect format
+	// Detect format from Content-Type / content probing
 	format := DetectFormat(location, contentType, data)
 	if pl != nil && pl.Logger != nil {
 		LogFormat(pl.Logger, location, format)
@@ -60,15 +78,16 @@ func Load(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 
 	switch format {
 	case FormatTSL:
-		// Delegate to TSL loader
+		// Delegate to TSL loader (will re-fetch; unavoidable without
+		// extension hint since LoadTSL handles references internally)
 		return LoadTSL(pl, ctx, args...)
 
 	case FormatLoTE:
-		// Parse LoTE directly from the fetched data
+		// Parse LoTE directly from the already-fetched data
 		return loadLoTEFromData(pl, ctx, location, data, args)
 
 	default:
-		return nil, fmt.Errorf("unable to detect format for %s (not XML or JSON)", location)
+		return ctx, fmt.Errorf("unable to detect format for %s (not XML or JSON)", location)
 	}
 }
 
@@ -82,7 +101,7 @@ func loadLoTEFromData(pl *Pipeline, ctx *Context, location string, data []byte, 
 	if len(args) >= 2 {
 		v, verr := jws.NewCertFileVerifier(args[1])
 		if verr != nil {
-			return nil, fmt.Errorf("failed to create JWS verifier from %s: %w", args[1], verr)
+			return ctx, fmt.Errorf("failed to create JWS verifier from %s: %w", args[1], verr)
 		}
 		verifier = v
 	}
@@ -94,18 +113,18 @@ func loadLoTEFromData(pl *Pipeline, ctx *Context, location string, data []byte, 
 		if verifier != nil {
 			payload, verifyErr := verifier.Verify(string(data))
 			if verifyErr != nil {
-				return nil, fmt.Errorf("failed to verify JWS for %s: %w", location, verifyErr)
+				return ctx, fmt.Errorf("failed to verify JWS for %s: %w", location, verifyErr)
 			}
 			lote, err = etsi119602.ParseLoTE(payload)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse verified LoTE from %s: %w", location, err)
+				return ctx, fmt.Errorf("failed to parse verified LoTE from %s: %w", location, err)
 			}
 		} else {
 			// Try as JWS compact serialization (unsigned verification just extracts payload)
 			if isJWSCompact(data) {
-				return nil, fmt.Errorf("LoTE at %s appears to be JWS-signed but no verification cert provided", location)
+				return ctx, fmt.Errorf("LoTE at %s appears to be JWS-signed but no verification cert provided", location)
 			}
-			return nil, fmt.Errorf("failed to parse LoTE from %s: %w", location, err)
+			return ctx, fmt.Errorf("failed to parse LoTE from %s: %w", location, err)
 		}
 	}
 

--- a/pkg/pipeline/step_merge_unified.go
+++ b/pkg/pipeline/step_merge_unified.go
@@ -47,7 +47,7 @@ func Merge(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 			}
 			return ctx, nil
 		}
-		return nil, fmt.Errorf("no trust lists in context to merge")
+		return ctx, fmt.Errorf("no trust lists in context to merge")
 	}
 
 	// Merge TSLs if present
@@ -59,7 +59,7 @@ func Merge(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 	if hasLoTEs {
 		_, err := MergeLoTEs(pl, ctx, args...)
 		if err != nil {
-			return nil, fmt.Errorf("merge LoTEs: %w", err)
+			return ctx, fmt.Errorf("merge LoTEs: %w", err)
 		}
 	}
 
@@ -125,7 +125,7 @@ func mergeTSLs(pl *Pipeline, ctx *Context) *Context {
 // Exported for explicit use via "merge-tsl:" step.
 func MergeTSLs(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 	if ctx.TSLs == nil || ctx.TSLs.Size() == 0 {
-		return nil, fmt.Errorf("no TSLs in context to merge")
+		return ctx, fmt.Errorf("no TSLs in context to merge")
 	}
 	return mergeTSLs(pl, ctx), nil
 }

--- a/pkg/pipeline/step_merge_unified.go
+++ b/pkg/pipeline/step_merge_unified.go
@@ -1,0 +1,131 @@
+package pipeline
+
+import (
+	"fmt"
+
+	"github.com/sirosfoundation/g119612/pkg/etsi119612"
+	"github.com/sirosfoundation/g119612/pkg/logging"
+)
+
+// Merge is a unified pipeline step that merges all trust lists of the same type
+// in the context into a single trust list per type.
+//
+// For LoTEs:
+//   - Merges all LoTEs into one, taking scheme info from the first
+//   - Concatenates trusted entities and pointers from all sources
+//
+// For TSLs:
+//   - Merges all TSLs into one, taking scheme info from the first
+//   - Concatenates trust service providers from all sources
+//
+// Usage in pipeline YAML:
+//
+//   - load:
+//   - https://example.com/list-se.json
+//   - load:
+//   - https://example.com/list-de.json
+//   - merge:
+//
+// To merge only a specific format, use the explicit steps:
+//   - merge-tsl: ...
+//   - merge-lote: ...
+func Merge(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
+	hasTSLs := ctx.TSLs != nil && ctx.TSLs.Size() > 1
+	hasLoTEs := ctx.LoTEs != nil && ctx.LoTEs.Size() > 1
+
+	if !hasTSLs && !hasLoTEs {
+		// Nothing to merge (need at least 2 of one type)
+		if ctx.TSLs != nil && ctx.TSLs.Size() == 1 {
+			if pl != nil && pl.Logger != nil {
+				pl.Logger.Debug("Only one TSL in context, nothing to merge")
+			}
+			return ctx, nil
+		}
+		if ctx.LoTEs != nil && ctx.LoTEs.Size() == 1 {
+			if pl != nil && pl.Logger != nil {
+				pl.Logger.Debug("Only one LoTE in context, nothing to merge")
+			}
+			return ctx, nil
+		}
+		return nil, fmt.Errorf("no trust lists in context to merge")
+	}
+
+	// Merge TSLs if present
+	if hasTSLs {
+		ctx = mergeTSLs(pl, ctx)
+	}
+
+	// Merge LoTEs if present
+	if hasLoTEs {
+		_, err := MergeLoTEs(pl, ctx, args...)
+		if err != nil {
+			return nil, fmt.Errorf("merge LoTEs: %w", err)
+		}
+	}
+
+	return ctx, nil
+}
+
+// mergeTSLs merges all TSLs in the context into a single TSL.
+func mergeTSLs(pl *Pipeline, ctx *Context) *Context {
+	tsls := ctx.TSLs.ToSlice()
+	if len(tsls) < 2 {
+		return ctx
+	}
+
+	// Take scheme information from the first TSL
+	merged := &etsi119612.TSL{
+		StatusList: etsi119612.TrustStatusListType{
+			TSLTagAttr:           tsls[0].StatusList.TSLTagAttr,
+			IdAttr:               tsls[0].StatusList.IdAttr,
+			TslSchemeInformation: tsls[0].StatusList.TslSchemeInformation,
+		},
+	}
+
+	// Merge trust service providers from all TSLs
+	var allProviders []*etsi119612.TSPType
+	for _, tsl := range tsls {
+		if tsl.StatusList.TslTrustServiceProviderList != nil {
+			allProviders = append(allProviders, tsl.StatusList.TslTrustServiceProviderList.TslTrustServiceProvider...)
+		}
+	}
+
+	merged.StatusList.TslTrustServiceProviderList = &etsi119612.TrustServiceProviderListType{
+		TslTrustServiceProvider: allProviders,
+	}
+
+	// Also merge pointers to other TSLs
+	var allPointers []*etsi119612.OtherTSLPointerType
+	for _, tsl := range tsls {
+		if tsl.StatusList.TslSchemeInformation != nil &&
+			tsl.StatusList.TslSchemeInformation.TslPointersToOtherTSL != nil {
+			allPointers = append(allPointers, tsl.StatusList.TslSchemeInformation.TslPointersToOtherTSL.TslOtherTSLPointer...)
+		}
+	}
+	if len(allPointers) > 0 && merged.StatusList.TslSchemeInformation != nil {
+		merged.StatusList.TslSchemeInformation.TslPointersToOtherTSL = &etsi119612.OtherTSLPointersType{
+			TslOtherTSLPointer: allPointers,
+		}
+	}
+
+	// Replace the stack with just the merged TSL
+	ctx.TSLs.Clear()
+	ctx.TSLs.Push(merged)
+
+	if pl != nil && pl.Logger != nil {
+		pl.Logger.Info("Merged TSLs",
+			logging.F("sources", len(tsls)),
+			logging.F("providers", len(allProviders)))
+	}
+
+	return ctx
+}
+
+// MergeTSLs merges all TSLs on the context stack into a single TSL.
+// Exported for explicit use via "merge-tsl:" step.
+func MergeTSLs(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
+	if ctx.TSLs == nil || ctx.TSLs.Size() == 0 {
+		return nil, fmt.Errorf("no TSLs in context to merge")
+	}
+	return mergeTSLs(pl, ctx), nil
+}

--- a/pkg/pipeline/step_publish_unified.go
+++ b/pkg/pipeline/step_publish_unified.go
@@ -1,0 +1,76 @@
+package pipeline
+
+import (
+	"fmt"
+
+	"github.com/sirosfoundation/g119612/pkg/logging"
+)
+
+// Publish is a unified pipeline step that publishes all trust lists in the context
+// to the specified output directory. It automatically handles both TSLs and LoTEs:
+//
+//   - TSLs are written as XML files (optionally signed with XML-DSIG)
+//   - LoTEs are written as JSON files (optionally signed with JWS)
+//
+// The step delegates to PublishTSL and/or PublishLoTE based on what's in the context.
+//
+// Usage in pipeline YAML:
+//
+//   - publish:
+//   - /path/to/output/dir                                              # Unsigned
+//   - publish:
+//   - ["/path/to/dir", "/cert.pem", "/key.pem"]                       # Signed (TSL=XML-DSIG, LoTE=JWS)
+//   - publish:
+//   - ["/path/to/dir", "pkcs11:module=/path;pin=1234", "key", "cert"] # PKCS#11 signing
+//
+// To publish only a specific format, use the explicit steps:
+//   - publish-tsl: ...   (or the alias: publish-xml:)
+//   - publish-lote: ...  (or the alias: publish-json:)
+func Publish(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
+	if len(args) < 1 {
+		return nil, fmt.Errorf("publish requires at least 1 argument: output directory")
+	}
+
+	hasTSLs := ctx.TSLs != nil && ctx.TSLs.Size() > 0
+	hasLoTEs := ctx.LoTEs != nil && ctx.LoTEs.Size() > 0
+
+	if !hasTSLs && !hasLoTEs {
+		return nil, fmt.Errorf("no trust lists in context to publish")
+	}
+
+	var errs []error
+
+	// Publish TSLs if present
+	if hasTSLs {
+		if pl != nil && pl.Logger != nil {
+			pl.Logger.Info("Publishing TSLs",
+				logging.F("count", ctx.TSLs.Size()),
+				logging.F("output", args[0]))
+		}
+		var err error
+		ctx, err = PublishTSL(pl, ctx, args...)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("publish TSL: %w", err))
+		}
+	}
+
+	// Publish LoTEs if present
+	if hasLoTEs {
+		if pl != nil && pl.Logger != nil {
+			pl.Logger.Info("Publishing LoTEs",
+				logging.F("count", ctx.LoTEs.Size()),
+				logging.F("output", args[0]))
+		}
+		var err error
+		ctx, err = PublishLoTE(pl, ctx, args...)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("publish LoTE: %w", err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return ctx, fmt.Errorf("publish errors: %v", errs)
+	}
+
+	return ctx, nil
+}

--- a/pkg/pipeline/step_publish_unified.go
+++ b/pkg/pipeline/step_publish_unified.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/sirosfoundation/g119612/pkg/logging"
@@ -28,14 +29,14 @@ import (
 //   - publish-lote: ...  (or the alias: publish-json:)
 func Publish(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 	if len(args) < 1 {
-		return nil, fmt.Errorf("publish requires at least 1 argument: output directory")
+		return ctx, fmt.Errorf("publish requires at least 1 argument: output directory")
 	}
 
 	hasTSLs := ctx.TSLs != nil && ctx.TSLs.Size() > 0
 	hasLoTEs := ctx.LoTEs != nil && ctx.LoTEs.Size() > 0
 
 	if !hasTSLs && !hasLoTEs {
-		return nil, fmt.Errorf("no trust lists in context to publish")
+		return ctx, fmt.Errorf("no trust lists in context to publish")
 	}
 
 	var errs []error
@@ -69,7 +70,7 @@ func Publish(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 	}
 
 	if len(errs) > 0 {
-		return ctx, fmt.Errorf("publish errors: %v", errs)
+		return ctx, errors.Join(errs...)
 	}
 
 	return ctx, nil

--- a/pkg/pipeline/steps_init.go
+++ b/pkg/pipeline/steps_init.go
@@ -2,21 +2,34 @@
 package pipeline
 
 func init() {
-	// Register all pipeline steps
-	RegisterFunction("load", LoadTSL)
-	RegisterFunction("select", SelectCertPool)           // Main name
-	RegisterFunction("select-cert-pool", SelectCertPool) // Alternative name for backward compatibility
-	RegisterFunction("echo", Echo)
-	RegisterFunction("generate", GenerateTSL)
-	RegisterFunction("publish", PublishTSL)
-	RegisterFunction("log", Log)
-	RegisterFunction("set-fetch-options", SetFetchOptions)
+	// Unified steps (auto-detect format based on content/extension/structure)
+	RegisterFunction("load", Load)       // Auto-detect TSL (XML) or LoTE (JSON)
+	RegisterFunction("publish", Publish) // Publish all trust lists in context
+	RegisterFunction("generate", Generate) // Auto-detect from directory structure
+	RegisterFunction("merge", Merge)       // Merge all trust lists of same type
 
-	// LoTE (ETSI TS 119 602) steps
+	// Explicit TSL (ETSI TS 119 612) steps
+	RegisterFunction("load-tsl", LoadTSL)
+	RegisterFunction("load-xml", LoadTSL)       // Alias
+	RegisterFunction("publish-tsl", PublishTSL)
+	RegisterFunction("publish-xml", PublishTSL) // Alias
+	RegisterFunction("generate-tsl", GenerateTSL)
+	RegisterFunction("merge-tsl", MergeTSLs)
+
+	// Explicit LoTE (ETSI TS 119 602) steps
 	RegisterFunction("load-lote", LoadLoTE)
-	RegisterFunction("generate-lote", GenerateLoTE)
+	RegisterFunction("load-json", LoadLoTE)       // Alias
 	RegisterFunction("publish-lote", PublishLoTE)
+	RegisterFunction("publish-json", PublishLoTE) // Alias
+	RegisterFunction("generate-lote", GenerateLoTE)
 	RegisterFunction("increment-lote-sequence", IncrementLoTESequence)
 	// convert-to-lote is registered via its own init() in step_convert_lote.go
 	// merge-lote is registered via its own init() in step_merge_lote.go
+
+	// Other steps
+	RegisterFunction("select", SelectCertPool)           // Main name
+	RegisterFunction("select-cert-pool", SelectCertPool) // Backward compatibility
+	RegisterFunction("echo", Echo)
+	RegisterFunction("log", Log)
+	RegisterFunction("set-fetch-options", SetFetchOptions)
 }

--- a/pkg/pipeline/steps_init.go
+++ b/pkg/pipeline/steps_init.go
@@ -3,14 +3,14 @@ package pipeline
 
 func init() {
 	// Unified steps (auto-detect format based on content/extension/structure)
-	RegisterFunction("load", Load)       // Auto-detect TSL (XML) or LoTE (JSON)
-	RegisterFunction("publish", Publish) // Publish all trust lists in context
+	RegisterFunction("load", Load)         // Auto-detect TSL (XML) or LoTE (JSON)
+	RegisterFunction("publish", Publish)   // Publish all trust lists in context
 	RegisterFunction("generate", Generate) // Auto-detect from directory structure
 	RegisterFunction("merge", Merge)       // Merge all trust lists of same type
 
 	// Explicit TSL (ETSI TS 119 612) steps
 	RegisterFunction("load-tsl", LoadTSL)
-	RegisterFunction("load-xml", LoadTSL)       // Alias
+	RegisterFunction("load-xml", LoadTSL) // Alias
 	RegisterFunction("publish-tsl", PublishTSL)
 	RegisterFunction("publish-xml", PublishTSL) // Alias
 	RegisterFunction("generate-tsl", GenerateTSL)
@@ -18,7 +18,7 @@ func init() {
 
 	// Explicit LoTE (ETSI TS 119 602) steps
 	RegisterFunction("load-lote", LoadLoTE)
-	RegisterFunction("load-json", LoadLoTE)       // Alias
+	RegisterFunction("load-json", LoadLoTE) // Alias
 	RegisterFunction("publish-lote", PublishLoTE)
 	RegisterFunction("publish-json", PublishLoTE) // Alias
 	RegisterFunction("generate-lote", GenerateLoTE)

--- a/pkg/pipeline/unified_test.go
+++ b/pkg/pipeline/unified_test.go
@@ -294,3 +294,119 @@ func TestUnifiedMerge(t *testing.T) {
 		}
 	})
 }
+
+// TestUnifiedErrorPaths verifies that all unified steps return a non-nil context
+// on error, so Pipeline.Process won't panic when accessing ctx.Report.
+func TestUnifiedErrorPaths(t *testing.T) {
+	t.Run("Load missing args", func(t *testing.T) {
+		ctx := &Context{}
+		pl := &Pipeline{}
+		result, err := Load(pl, ctx)
+		if err == nil {
+			t.Fatal("expected error for missing args")
+		}
+		if result == nil {
+			t.Fatal("expected non-nil context on error")
+		}
+	})
+
+	t.Run("Load unknown format", func(t *testing.T) {
+		// Create a file with binary content and no extension
+		tmpDir := t.TempDir()
+		binPath := filepath.Join(tmpDir, "mystery")
+		if err := os.WriteFile(binPath, []byte{0x00, 0x01, 0x02}, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := &Context{}
+		pl := &Pipeline{Logger: logging.NewLogger(logging.ErrorLevel)}
+		result, err := Load(pl, ctx, binPath)
+		if err == nil {
+			t.Fatal("expected error for unknown format")
+		}
+		if result == nil {
+			t.Fatal("expected non-nil context on error")
+		}
+	})
+
+	t.Run("Load nonexistent file", func(t *testing.T) {
+		ctx := &Context{}
+		pl := &Pipeline{Logger: logging.NewLogger(logging.ErrorLevel)}
+		result, err := Load(pl, ctx, "/nonexistent/file.xml")
+		if err == nil {
+			t.Fatal("expected error for nonexistent file")
+		}
+		if result == nil {
+			t.Fatal("expected non-nil context on error")
+		}
+	})
+
+	t.Run("Publish missing args", func(t *testing.T) {
+		ctx := &Context{}
+		result, err := Publish(nil, ctx)
+		if err == nil {
+			t.Fatal("expected error for missing args")
+		}
+		if result == nil {
+			t.Fatal("expected non-nil context on error")
+		}
+	})
+
+	t.Run("Publish empty context", func(t *testing.T) {
+		ctx := &Context{}
+		result, err := Publish(nil, ctx, "/tmp/out")
+		if err == nil {
+			t.Fatal("expected error for empty context")
+		}
+		if result == nil {
+			t.Fatal("expected non-nil context on error")
+		}
+	})
+
+	t.Run("Merge empty context", func(t *testing.T) {
+		ctx := &Context{}
+		result, err := Merge(nil, ctx)
+		if err == nil {
+			t.Fatal("expected error for empty context")
+		}
+		if result == nil {
+			t.Fatal("expected non-nil context on error")
+		}
+	})
+
+	t.Run("MergeTSLs empty stack", func(t *testing.T) {
+		ctx := &Context{
+			TSLs: utils.NewStack[*etsi119612.TSL](),
+		}
+		result, err := MergeTSLs(nil, ctx)
+		if err == nil {
+			t.Fatal("expected error for empty TSL stack")
+		}
+		if result == nil {
+			t.Fatal("expected non-nil context on error")
+		}
+	})
+
+	t.Run("Generate missing args", func(t *testing.T) {
+		ctx := &Context{}
+		result, err := Generate(nil, ctx)
+		if err == nil {
+			t.Fatal("expected error for missing args")
+		}
+		if result == nil {
+			t.Fatal("expected non-nil context on error")
+		}
+	})
+
+	t.Run("Generate empty directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		ctx := &Context{}
+		result, err := Generate(nil, ctx, tmpDir)
+		if err == nil {
+			t.Fatal("expected error for empty directory")
+		}
+		if result == nil {
+			t.Fatal("expected non-nil context on error")
+		}
+	})
+}

--- a/pkg/pipeline/unified_test.go
+++ b/pkg/pipeline/unified_test.go
@@ -1,0 +1,296 @@
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sirosfoundation/g119612/pkg/etsi119602"
+	"github.com/sirosfoundation/g119612/pkg/etsi119612"
+	"github.com/sirosfoundation/g119612/pkg/logging"
+	"github.com/sirosfoundation/g119612/pkg/utils"
+)
+
+func TestDetectFormat(t *testing.T) {
+	tests := []struct {
+		name        string
+		location    string
+		contentType string
+		data        []byte
+		want        Format
+	}{
+		// Extension-based detection
+		{name: "xml extension", location: "https://example.com/tsl.xml", want: FormatTSL},
+		{name: "json extension", location: "https://example.com/lote.json", want: FormatLoTE},
+		{name: "jws extension", location: "https://example.com/lote.jws", want: FormatLoTE},
+		{name: "xml extension with query", location: "https://example.com/tsl.xml?v=1", want: FormatTSL},
+
+		// Content-Type based detection
+		{name: "application/xml", location: "https://example.com/tsl", contentType: "application/xml", want: FormatTSL},
+		{name: "text/xml", location: "https://example.com/tsl", contentType: "text/xml; charset=utf-8", want: FormatTSL},
+		{name: "application/json", location: "https://example.com/lote", contentType: "application/json", want: FormatLoTE},
+
+		// Content probing
+		{name: "xml content", location: "https://example.com/data", data: []byte("<?xml version=\"1.0\""), want: FormatTSL},
+		{name: "xml content with bom", location: "https://example.com/data", data: []byte("\xef\xbb\xbf<?xml"), want: FormatTSL},
+		{name: "json object content", location: "https://example.com/data", data: []byte(`{"version": "1.0"}`), want: FormatLoTE},
+		{name: "json array content", location: "https://example.com/data", data: []byte(`[{"id": 1}]`), want: FormatLoTE},
+		{name: "jws compact", location: "https://example.com/data", data: []byte("eyJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.sig"), want: FormatLoTE},
+
+		// Unknown
+		{name: "empty location", location: "", want: FormatUnknown},
+		{name: "empty data", location: "https://example.com/data", data: []byte(""), want: FormatUnknown},
+		{name: "binary data", location: "https://example.com/data", data: []byte{0x00, 0x01, 0x02}, want: FormatUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectFormat(tt.location, tt.contentType, tt.data)
+			if got != tt.want {
+				t.Errorf("DetectFormat(%q, %q, %v) = %q, want %q", tt.location, tt.contentType, tt.data, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnifiedLoad(t *testing.T) {
+	// Create temporary test files
+	tmpDir := t.TempDir()
+
+	// Create a simple XML TSL file
+	tslContent := `<?xml version="1.0" encoding="UTF-8"?>
+<TrustServiceStatusList xmlns="http://uri.etsi.org/02231/v2#">
+	<SchemeInformation>
+		<TSLVersionIdentifier>5</TSLVersionIdentifier>
+		<TSLSequenceNumber>1</TSLSequenceNumber>
+		<TSLType>http://uri.etsi.org/TrstSvc/TrustedList/TSLType/EUgeneric</TSLType>
+		<SchemeOperatorName>
+			<Name xml:lang="en">Test Operator</Name>
+		</SchemeOperatorName>
+		<SchemeTerritory>XX</SchemeTerritory>
+	</SchemeInformation>
+</TrustServiceStatusList>`
+	tslPath := filepath.Join(tmpDir, "test.xml")
+	if err := os.WriteFile(tslPath, []byte(tslContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a simple JSON LoTE file
+	loteContent := `{
+		"version": "1.0",
+		"schemeInformation": {
+			"territory": "XX",
+			"schemeOperator": [{"language": "en", "value": "Test Operator"}],
+			"schemeType": "test",
+			"sequenceNumber": 1,
+			"issueDate": "2024-01-01T00:00:00Z"
+		},
+		"trustedEntities": []
+	}`
+	lotePath := filepath.Join(tmpDir, "test.json")
+	if err := os.WriteFile(lotePath, []byte(loteContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		location  string
+		wantTSL   bool
+		wantLoTE  bool
+		wantError bool
+	}{
+		{name: "load xml as tsl", location: tslPath, wantTSL: true},
+		{name: "load json as lote", location: lotePath, wantLoTE: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &Context{}
+			// Create pipeline with logger to avoid nil pointer in LoadTSL
+			pl := &Pipeline{Logger: logging.NewLogger(logging.ErrorLevel)}
+
+			ctx, err := Load(pl, ctx, tt.location)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantTSL && (ctx.TSLs == nil || ctx.TSLs.Size() == 0) {
+				t.Error("expected TSL to be loaded")
+			}
+			if tt.wantLoTE && (ctx.LoTEs == nil || ctx.LoTEs.Size() == 0) {
+				t.Error("expected LoTE to be loaded")
+			}
+		})
+	}
+}
+
+func TestUnifiedPublish(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a context with both TSL and LoTE
+	ctx := &Context{
+		TSLs:  utils.NewStack[*etsi119612.TSL](),
+		LoTEs: utils.NewStack[*etsi119602.ListOfTrustedEntities](),
+	}
+
+	// Add a minimal TSL
+	ctx.TSLs.Push(&etsi119612.TSL{
+		StatusList: etsi119612.TrustStatusListType{
+			TslSchemeInformation: &etsi119612.TSLSchemeInformationType{
+				TSLVersionIdentifier: 5,
+				TslSchemeTerritory:   "XX",
+			},
+		},
+	})
+
+	// Add a minimal LoTE
+	ctx.LoTEs.Push(&etsi119602.ListOfTrustedEntities{
+		Version: "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{
+			Territory:      "XX",
+			SchemeType:     "test",
+			SchemeOperator: etsi119602.NameSet{{Language: "en", Value: "Test Operator"}},
+			IssueDate:      time.Now().UTC(),
+		},
+	})
+
+	pl := &Pipeline{Logger: logging.NewLogger(logging.ErrorLevel)}
+	_, err := Publish(pl, ctx, tmpDir)
+	if err != nil {
+		t.Fatalf("Publish failed: %v", err)
+	}
+
+	// Check that files were created
+	entries, _ := os.ReadDir(tmpDir)
+	if len(entries) == 0 {
+		t.Error("expected files to be published")
+	}
+}
+
+func TestUnifiedGenerate(t *testing.T) {
+	// Test with LoTE structure
+	t.Run("detect LoTE structure", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Create entities directory (LoTE indicator)
+		entitiesDir := filepath.Join(tmpDir, "entities")
+		if err := os.MkdirAll(entitiesDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create minimal scheme.yaml
+		schemeYAML := `operatorNames:
+  - language: en
+    value: Test Operator
+schemeType: test
+territory: XX
+`
+		if err := os.WriteFile(filepath.Join(tmpDir, "scheme.yaml"), []byte(schemeYAML), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := &Context{}
+		pl := &Pipeline{}
+
+		ctx, err := Generate(pl, ctx, tmpDir)
+		if err != nil {
+			t.Fatalf("Generate failed: %v", err)
+		}
+
+		if ctx.LoTEs == nil || ctx.LoTEs.Size() == 0 {
+			t.Error("expected LoTE to be generated")
+		}
+	})
+
+	// Test with ambiguous structure (both providers and entities)
+	t.Run("reject ambiguous structure", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		if err := os.MkdirAll(filepath.Join(tmpDir, "providers"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(tmpDir, "entities"), 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := &Context{}
+		pl := &Pipeline{}
+
+		_, err := Generate(pl, ctx, tmpDir)
+		if err == nil {
+			t.Error("expected error for ambiguous structure")
+		}
+	})
+}
+
+func TestUnifiedMerge(t *testing.T) {
+	t.Run("merge multiple LoTEs", func(t *testing.T) {
+		ctx := &Context{
+			LoTEs: utils.NewStack[*etsi119602.ListOfTrustedEntities](),
+		}
+
+		// Add two LoTEs
+		ctx.LoTEs.Push(&etsi119602.ListOfTrustedEntities{
+			Version: "1.0",
+			SchemeInformation: etsi119602.SchemeInformation{
+				Territory: "SE",
+			},
+			TrustedEntities: []etsi119602.TrustedEntity{
+				{EntityID: "urn:entity:1"},
+			},
+		})
+		ctx.LoTEs.Push(&etsi119602.ListOfTrustedEntities{
+			Version: "1.0",
+			SchemeInformation: etsi119602.SchemeInformation{
+				Territory: "DE",
+			},
+			TrustedEntities: []etsi119602.TrustedEntity{
+				{EntityID: "urn:entity:2"},
+			},
+		})
+
+		pl := &Pipeline{}
+		ctx, err := Merge(pl, ctx)
+		if err != nil {
+			t.Fatalf("Merge failed: %v", err)
+		}
+
+		if ctx.LoTEs.Size() != 1 {
+			t.Errorf("expected 1 merged LoTE, got %d", ctx.LoTEs.Size())
+		}
+
+		merged, ok := ctx.LoTEs.Peek()
+		if !ok {
+			t.Fatal("expected to peek merged LoTE")
+		}
+		if len(merged.TrustedEntities) != 2 {
+			t.Errorf("expected 2 entities in merged LoTE, got %d", len(merged.TrustedEntities))
+		}
+	})
+
+	t.Run("single item no merge needed", func(t *testing.T) {
+		ctx := &Context{
+			LoTEs: utils.NewStack[*etsi119602.ListOfTrustedEntities](),
+		}
+		ctx.LoTEs.Push(&etsi119602.ListOfTrustedEntities{Version: "1.0"})
+
+		pl := &Pipeline{}
+		ctx, err := Merge(pl, ctx)
+		if err != nil {
+			t.Fatalf("Merge failed: %v", err)
+		}
+
+		if ctx.LoTEs.Size() != 1 {
+			t.Errorf("expected 1 LoTE (unchanged), got %d", ctx.LoTEs.Size())
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Add unified pipeline steps that auto-detect trust list format based on:
- File extension (.xml → TSL, .json → LoTE)
- HTTP Content-Type header
- Content probing (first non-whitespace byte)

## New Unified Steps

| Step | Behavior |
|------|----------|
| `load` | Auto-detect TSL (XML) or LoTE (JSON) |
| `publish` | Publish all trust lists in context (both TSL and LoTE) |
| `generate` | Auto-detect format from directory structure (providers/ → TSL, entities/ → LoTE) |
| `merge` | Merge all trust lists of the same type |

## Explicit Format Steps (backward compatible)

Explicit format steps remain available as aliases:
- `load-tsl`/`load-xml`, `load-lote`/`load-json`
- `publish-tsl`/`publish-xml`, `publish-lote`/`publish-json`
- `generate-tsl`, `generate-lote`
- `merge-tsl`, `merge-lote`

## New Files

- `format.go` - Format detection utilities
- `step_load_unified.go` - Unified load step
- `step_publish_unified.go` - Unified publish step
- `step_generate_unified.go` - Unified generate step
- `step_merge_unified.go` - Unified merge step + MergeTSLs function
- `unified_test.go` - Tests for all unified steps
- `pkcs11_signer_test.go` - Additional JWS tests

## Test Coverage

All packages now have >70% test coverage:

| Package | Coverage |
|---------|----------|
| jws | 74.1% (was 42%) |
| pipeline | 78.3% |
| dsig | 86.1% |
| validation | 95.9% |
