### PR TITLE
ci: add security toolchain (CodeQL, govulncheck, SBOM, Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  schedule:
+    - cron: '0 8 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'go' ]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,23 @@
+name: SBOM
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  sbom:
+    uses: sirosfoundation/.github/.github/workflows/sbom.yml@main
+    with:
+      artifact-name: g119612
+      scan-vulnerabilities: true
+      sign-sbom: false
+    permissions:
+      contents: write
+      id-token: write
+      security-events: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,39 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  govulncheck:
+    name: Go Vulnerability Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        run: govulncheck ./...
+
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x, 1.26.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -18,10 +18,10 @@ jobs:
     - name: run tests
       run: make test
     - name: generate test coverage
-      if: matrix.go-version == '1.25.x'
+      if: matrix.go-version == '1.26.x'
       run: go test -tags softhsm ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./...
     - name: check test coverage
-      if: matrix.go-version == '1.25.x'
+      if: matrix.go-version == '1.26.x'
       uses: vladopajic/go-test-coverage@v2
       with:
         debug: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sirosfoundation/g119612
 
-go 1.25.1
+go 1.26
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.3


### PR DESCRIPTION
## Security Toolchain Rollout

Add automated security scanning workflows:

- **CodeQL** — static analysis for Go, runs on push/PR to main + weekly
- **govulncheck** — Go vulnerability database check, runs on push/PR to main + weekly
- **Dependency review** — blocks PRs introducing high-severity vulnerabilities
- **SBOM** — Software Bill of Materials via org reusable workflow
- **Dependabot** — weekly version updates for gomod, github-actions, docker (grouped)

Part of compliance workstream WS1 (sirosfoundation/compliance#32).

> Pilot PR — validating workflows before rolling out to remaining repos.