### PR TITLE
fix: harden security workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-      - '**.md'
+      - '**/*.md'
       - 'docs/**'
   pull_request:
     branches: [ main ]
     paths-ignore:
-      - '**.md'
+      - '**/*.md'
       - 'docs/**'
   schedule:
     - cron: '0 8 * * 1'

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   sbom:
-    uses: sirosfoundation/.github/.github/workflows/sbom.yml@main
+    uses: sirosfoundation/.github/.github/workflows/sbom.yml@03160e376dbdeb9f2c904e7a9f45499b2f67e8fa # main
     with:
       artifact-name: g119612
       scan-vulnerabilities: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   govulncheck:
@@ -23,7 +22,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
       - name: Run govulncheck
         run: govulncheck ./...
 


### PR DESCRIPTION
Follow-up to PR #19 — applies review fixes that were identified after the initial toolchain rollout was merged.

## Changes
- **Pin govulncheck to v1.1.4** (was `@latest`) for reproducible builds
- **Remove `security-events: write`** permission (neither govulncheck nor dependency-review uploads SARIF)
- **Fix paths-ignore glob**: `**.md` → `**/*.md` for proper recursive matching
- **Pin SBOM reusable workflow** to commit SHA instead of `@main`