### PR TITLE
ci: use go-version-file instead of version matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,25 +3,19 @@ name: Test
 permissions: write-all
 jobs:
   test:
-    strategy:
-      matrix:
-        go-version: [1.25.x, 1.26.x]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-         go-version: ${{ matrix.go-version }}
+         go-version-file: go.mod
     - name: install dependencies
       run: sudo apt-get update && sudo apt-get install -y softhsm2 opensc xsltproc
     - name: run tests
       run: make test
     - name: generate test coverage
-      if: matrix.go-version == '1.26.x'
       run: go test -tags softhsm ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./...
     - name: check test coverage
-      if: matrix.go-version == '1.26.x'
       uses: vladopajic/go-test-coverage@v2
       with:
         debug: true


### PR DESCRIPTION
Remove the multi-version test matrix (was testing 1.25.x + 1.26.x) and use `go-version-file: go.mod` so CI always matches the Go version declared in go.mod (currently 1.26).

Removes now-unnecessary `if: matrix.go-version == '1.26.x'` conditionals on coverage steps.