### PR TITLE
feat: JAdES-B-B and XAdES-B-B signature compliance

### DIFF
--- a/pkg/dsig/file_signer.go
+++ b/pkg/dsig/file_signer.go
@@ -14,16 +14,20 @@ import (
 // FileSigner implements XMLSigner using certificate and private key files.
 // It uses file-based certificates and keys for signing XML documents.
 // The certificate and key files should be in PEM format.
+// By default, it produces XAdES-B-B compliant signatures.
 type FileSigner struct {
 	// CertFile is the path to the X.509 certificate file in PEM format
 	CertFile string
 
 	// KeyFile is the path to the private key file in PEM format (PKCS#1 or PKCS#8)
 	KeyFile string
+
+	// xades controls whether XAdES-B-B QualifyingProperties are added (default: true)
+	xades bool
 }
 
 // NewFileSigner creates a new FileSigner from certificate and key file paths.
-// This is a convenience constructor for the FileSigner struct.
+// XAdES-B-B compliance is enabled by default.
 //
 // Parameters:
 //   - certFile: Path to the X.509 certificate file in PEM format
@@ -35,7 +39,13 @@ func NewFileSigner(certFile, keyFile string) *FileSigner {
 	return &FileSigner{
 		CertFile: certFile,
 		KeyFile:  keyFile,
+		xades:    true,
 	}
+}
+
+// SetXAdES enables or disables XAdES-B-B compliant signatures.
+func (fs *FileSigner) SetXAdES(enabled bool) {
+	fs.xades = enabled
 }
 
 // Sign implements XMLSigner.Sign using certificate and key files.
@@ -99,7 +109,12 @@ func (fs *FileSigner) Sign(xmlData []byte) ([]byte, error) {
 		}
 	}
 
-	// Create a key store from the loaded certificate and private key
+	// Use XAdES-B-B signing if enabled
+	if fs.xades {
+		return SignXMLWithXAdES(xmlData, privateKey, cert)
+	}
+
+	// Fall back to plain XML-DSIG
 	keyStore := &fileKeyStore{
 		cert: cert,
 		key:  privateKey,

--- a/pkg/dsig/pkcs11_signer.go
+++ b/pkg/dsig/pkcs11_signer.go
@@ -15,6 +15,7 @@ import (
 // PKCS11Signer implements XMLSigner using a PKCS#11 hardware token.
 // This type provides XML digital signature functionality using keys stored in
 // Hardware Security Modules (HSMs) or other PKCS#11-compatible devices.
+// By default, it produces XAdES-B-B compliant signatures.
 type PKCS11Signer struct {
 	// Config contains the PKCS#11 module configuration (path, PIN, etc.)
 	Config *crypto11.Config
@@ -33,11 +34,13 @@ type PKCS11Signer struct {
 
 	// initialized indicates if the PKCS#11 context has been initialized
 	initialized bool
+
+	// xades controls whether XAdES-B-B QualifyingProperties are added (default: true)
+	xades bool
 }
 
 // NewPKCS11Signer creates a new PKCS11Signer from a PKCS#11 configuration and key/cert labels.
-// This constructor initializes a signer with the provided configuration but does not
-// connect to the PKCS#11 module until signing operations are performed.
+// XAdES-B-B compliance is enabled by default.
 //
 // Parameters:
 //   - config: PKCS#11 module configuration (path, PIN, token label, etc.)
@@ -52,6 +55,7 @@ func NewPKCS11Signer(config *crypto11.Config, keyLabel, certLabel string) *PKCS1
 		keyLabel:  keyLabel,
 		certLabel: certLabel,
 		keyID:     "01", // Default ID, can be set with SetKeyID
+		xades:     true,
 	}
 }
 
@@ -124,6 +128,11 @@ func (ps *PKCS11Signer) SetKeyID(id string) {
 	ps.keyID = id
 }
 
+// SetXAdES enables or disables XAdES-B-B compliant signatures.
+func (ps *PKCS11Signer) SetXAdES(enabled bool) {
+	ps.xades = enabled
+}
+
 // hexToBytes converts a hex string to bytes (handling both with and without '0x' prefix).
 // This helper function normalizes hex strings for use as PKCS#11 object IDs.
 //
@@ -167,7 +176,6 @@ func (ps *PKCS11Signer) Sign(xmlData []byte) ([]byte, error) {
 	}
 
 	// Get the private key by ID and label
-	// The crypto11 FindKeyPair function takes (id, label) parameters
 	privateKey, err := ps.context.FindKeyPair(idBytes, []byte(ps.keyLabel))
 	if err != nil {
 		return nil, fmt.Errorf("failed to find private key with label '%s' and ID '%s': %w",
@@ -175,15 +183,18 @@ func (ps *PKCS11Signer) Sign(xmlData []byte) ([]byte, error) {
 	}
 
 	// Get the certificate by ID and label
-	// The crypto11 FindCertificate function takes (id, label, serial) parameters
 	cert, err := ps.context.FindCertificate(idBytes, []byte(ps.certLabel), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find certificate with label '%s' and ID '%s': %w",
 			ps.certLabel, ps.keyID, err)
 	}
 
-	// Create a goxmldsig PKCS11Signer that implements the Signer interface
-	// Using SHA256 as the default hash algorithm
+	// Use XAdES-B-B signing if enabled
+	if ps.xades {
+		return SignXMLWithXAdES(xmlData, privateKey, cert)
+	}
+
+	// Fall back to plain XML-DSIG
 	pkcs11Signer, err := xmldsig.NewPKCS11Signer(privateKey, cert.Raw, crypto.SHA256)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create PKCS11Signer: %w", err)

--- a/pkg/dsig/signer.go
+++ b/pkg/dsig/signer.go
@@ -16,7 +16,8 @@ import (
 // key storage mechanisms.
 type XMLSigner interface {
 	// Sign takes XML data as bytes and returns the signed XML data.
-	// The signature is added according to the XML-DSIG standard.
+	// The signature is added according to the XML-DSIG standard,
+	// with XAdES-B-B qualifying properties by default.
 	//
 	// Parameters:
 	//   - xmlData: The raw XML data to sign
@@ -25,6 +26,11 @@ type XMLSigner interface {
 	//   - The signed XML data
 	//   - An error if signing fails
 	Sign(xmlData []byte) ([]byte, error)
+}
+
+// XAdESConfigurable allows configuring XAdES compliance on a signer.
+type XAdESConfigurable interface {
+	SetXAdES(enabled bool)
 }
 
 // X509KeyStore defines an interface for accessing X.509 certificates and private keys.

--- a/pkg/dsig/xades.go
+++ b/pkg/dsig/xades.go
@@ -1,0 +1,264 @@
+// Package dsig provides XML Digital Signature (XML-DSIG) functionality.
+// This file implements XAdES-B-B (ETSI TS 101 903 / ETSI EN 319 132-1)
+// qualified electronic signatures for Trust Status Lists.
+
+package dsig
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/beevik/etree"
+	xmldsig "github.com/russellhaering/goxmldsig"
+)
+
+const (
+	xadesNamespace      = "http://uri.etsi.org/01903/v1.3.2#"
+	dsigNamespace       = "http://www.w3.org/2000/09/xmldsig#"
+	excC14NAlgorithm    = "http://www.w3.org/2001/10/xml-exc-c14n#"
+	sha256DigestAlg     = "http://www.w3.org/2001/04/xmlenc#sha256"
+	envelopedSigAlg     = "http://www.w3.org/2000/09/xmldsig#enveloped-signature"
+	rsaSHA256SigAlg     = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+	signedPropertiesType = "http://uri.etsi.org/01903#SignedProperties"
+)
+
+// SignXMLWithXAdES signs XML data with an enveloped XAdES-B-B signature.
+// This creates a full XAdES-B-B signature including:
+//   - ds:Signature with two ds:Reference elements (document + SignedProperties)
+//   - ds:Object containing xades:QualifyingProperties
+//   - xades:SignedProperties with SigningTime, SigningCertificate, and DataObjectFormat
+//
+// Parameters:
+//   - xmlData: Raw XML bytes to sign
+//   - signer: crypto.Signer for signing (e.g., *rsa.PrivateKey or PKCS#11 opaque signer)
+//   - cert: X.509 certificate of the signer
+func SignXMLWithXAdES(xmlData []byte, signer crypto.Signer, cert *x509.Certificate) ([]byte, error) {
+	doc := etree.NewDocument()
+	if err := doc.ReadFromBytes(xmlData); err != nil {
+		return nil, fmt.Errorf("failed to parse XML: %w", err)
+	}
+
+	root := doc.Root()
+
+	// Generate a unique signature ID
+	sigID := generateSignatureID()
+	signedPropsID := "xades-" + sigID
+
+	// Build the QualifyingProperties / SignedProperties element
+	object := buildXAdESObject(sigID, signedPropsID, cert)
+
+	// Canonicalize the SignedProperties for the second reference digest
+	signedPropsDigest, err := digestSignedProperties(object, signedPropsID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to digest SignedProperties: %w", err)
+	}
+
+	// Compute digest of the document (with enveloped-signature transform)
+	docDigest, err := digestDocument(root)
+	if err != nil {
+		return nil, fmt.Errorf("failed to digest document: %w", err)
+	}
+
+	// Build SignedInfo with two references
+	signedInfo := buildSignedInfo(docDigest, signedPropsDigest, signedPropsID)
+
+	// Canonicalize SignedInfo and sign it
+	signedInfoDigest, err := canonicalizeAndHash(signedInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to canonicalize SignedInfo: %w", err)
+	}
+
+	rawSignature, err := signer.Sign(rand.Reader, signedInfoDigest, crypto.SHA256)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign: %w", err)
+	}
+
+	// Build the complete Signature element
+	sig := buildSignatureElement(signedInfo, rawSignature, cert, object, sigID)
+
+	// Append signature to a copy of the root
+	result := root.Copy()
+	result.AddChild(sig)
+
+	outDoc := etree.NewDocument()
+	outDoc.SetRoot(result)
+	return outDoc.WriteToBytes()
+}
+
+// generateSignatureID generates a deterministic-format signature ID.
+func generateSignatureID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return fmt.Sprintf("%x", b)
+}
+
+// buildXAdESObject constructs the ds:Object element containing xades:QualifyingProperties.
+func buildXAdESObject(sigID, signedPropsID string, cert *x509.Certificate) *etree.Element {
+	object := etree.NewElement("ds:Object")
+
+	qp := object.CreateElement("xades:QualifyingProperties")
+	qp.CreateAttr("xmlns:xades", xadesNamespace)
+	qp.CreateAttr("Target", "#"+sigID)
+
+	sp := qp.CreateElement("xades:SignedProperties")
+	sp.CreateAttr("Id", signedPropsID)
+
+	// SignedSignatureProperties
+	ssp := sp.CreateElement("xades:SignedSignatureProperties")
+
+	// SigningTime
+	signingTime := ssp.CreateElement("xades:SigningTime")
+	signingTime.SetText(time.Now().UTC().Format("2006-01-02T15:04:05Z"))
+
+	// SigningCertificate
+	sigCert := ssp.CreateElement("xades:SigningCertificate")
+	certElem := sigCert.CreateElement("xades:Cert")
+
+	// CertDigest (SHA-256)
+	certDigest := certElem.CreateElement("xades:CertDigest")
+	digestMethod := certDigest.CreateElement("ds:DigestMethod")
+	digestMethod.CreateAttr("Algorithm", sha256DigestAlg)
+	hash := sha256.Sum256(cert.Raw)
+	digestValue := certDigest.CreateElement("ds:DigestValue")
+	digestValue.SetText(base64.StdEncoding.EncodeToString(hash[:]))
+
+	// IssuerSerial
+	issuerSerial := certElem.CreateElement("xades:IssuerSerial")
+	issuerName := issuerSerial.CreateElement("ds:X509IssuerName")
+	issuerName.SetText(cert.Issuer.String())
+	serialNumber := issuerSerial.CreateElement("ds:X509SerialNumber")
+	serialNumber.SetText(cert.SerialNumber.String())
+
+	// SignedDataObjectProperties
+	sdop := sp.CreateElement("xades:SignedDataObjectProperties")
+	dof := sdop.CreateElement("xades:DataObjectFormat")
+	dof.CreateAttr("ObjectReference", "#r-doc-"+sigID)
+	mimeType := dof.CreateElement("xades:MimeType")
+	mimeType.SetText("text/xml")
+
+	return object
+}
+
+// buildSignedInfo constructs the ds:SignedInfo element with two references.
+func buildSignedInfo(docDigest, signedPropsDigest []byte, signedPropsID string) *etree.Element {
+	signedInfo := etree.NewElement("ds:SignedInfo")
+	signedInfo.CreateAttr("xmlns:ds", dsigNamespace)
+
+	// CanonicalizationMethod
+	c14n := signedInfo.CreateElement("ds:CanonicalizationMethod")
+	c14n.CreateAttr("Algorithm", excC14NAlgorithm)
+
+	// SignatureMethod
+	sigMethod := signedInfo.CreateElement("ds:SignatureMethod")
+	sigMethod.CreateAttr("Algorithm", rsaSHA256SigAlg)
+
+	// Reference 1: the document
+	ref1 := signedInfo.CreateElement("ds:Reference")
+	ref1.CreateAttr("URI", "")
+	transforms := ref1.CreateElement("ds:Transforms")
+	t1 := transforms.CreateElement("ds:Transform")
+	t1.CreateAttr("Algorithm", envelopedSigAlg)
+	t2 := transforms.CreateElement("ds:Transform")
+	t2.CreateAttr("Algorithm", excC14NAlgorithm)
+	dm1 := ref1.CreateElement("ds:DigestMethod")
+	dm1.CreateAttr("Algorithm", sha256DigestAlg)
+	dv1 := ref1.CreateElement("ds:DigestValue")
+	dv1.SetText(base64.StdEncoding.EncodeToString(docDigest))
+
+	// Reference 2: SignedProperties
+	ref2 := signedInfo.CreateElement("ds:Reference")
+	ref2.CreateAttr("Type", signedPropertiesType)
+	ref2.CreateAttr("URI", "#"+signedPropsID)
+	transforms2 := ref2.CreateElement("ds:Transforms")
+	t3 := transforms2.CreateElement("ds:Transform")
+	t3.CreateAttr("Algorithm", excC14NAlgorithm)
+	dm2 := ref2.CreateElement("ds:DigestMethod")
+	dm2.CreateAttr("Algorithm", sha256DigestAlg)
+	dv2 := ref2.CreateElement("ds:DigestValue")
+	dv2.SetText(base64.StdEncoding.EncodeToString(signedPropsDigest))
+
+	return signedInfo
+}
+
+// buildSignatureElement assembles the complete ds:Signature element.
+func buildSignatureElement(signedInfo *etree.Element, rawSignature []byte, cert *x509.Certificate, object *etree.Element, sigID string) *etree.Element {
+	sig := etree.NewElement("ds:Signature")
+	sig.CreateAttr("xmlns:ds", dsigNamespace)
+	sig.CreateAttr("Id", sigID)
+
+	// Remove the temporary xmlns:ds from SignedInfo (it's inherited from Signature)
+	signedInfo.RemoveAttr("xmlns:ds")
+	sig.AddChild(signedInfo)
+
+	// SignatureValue
+	sigValue := sig.CreateElement("ds:SignatureValue")
+	sigValue.SetText(base64.StdEncoding.EncodeToString(rawSignature))
+
+	// KeyInfo
+	keyInfo := sig.CreateElement("ds:KeyInfo")
+	x509Data := keyInfo.CreateElement("ds:X509Data")
+	x509Cert := x509Data.CreateElement("ds:X509Certificate")
+	x509Cert.SetText(base64.StdEncoding.EncodeToString(cert.Raw))
+
+	// Object (containing QualifyingProperties)
+	sig.AddChild(object)
+
+	return sig
+}
+
+// digestDocument computes the SHA-256 digest of the document root after
+// applying exclusive canonicalization (simulating the enveloped-signature transform).
+func digestDocument(root *etree.Element) ([]byte, error) {
+	canonicalizer := xmldsig.MakeC14N10ExclusiveCanonicalizerWithPrefixList("")
+	canonical, err := canonicalizer.Canonicalize(root)
+	if err != nil {
+		return nil, err
+	}
+	hash := sha256.Sum256(canonical)
+	return hash[:], nil
+}
+
+// digestSignedProperties computes the SHA-256 digest of the SignedProperties element
+// after exclusive canonicalization.
+func digestSignedProperties(object *etree.Element, signedPropsID string) ([]byte, error) {
+	// Find the SignedProperties element inside the Object
+	qp := object.FindElement("xades:QualifyingProperties")
+	if qp == nil {
+		return nil, fmt.Errorf("QualifyingProperties not found")
+	}
+	sp := qp.FindElement("xades:SignedProperties")
+	if sp == nil {
+		return nil, fmt.Errorf("SignedProperties not found")
+	}
+
+	// For exclusive canonicalization, we need to create a detached copy
+	// with the necessary namespace declarations visible on the element itself,
+	// since exclusive C14N requires namespace declarations to be visibly utilized.
+	spCopy := sp.Copy()
+	spCopy.CreateAttr("xmlns:xades", xadesNamespace)
+	spCopy.CreateAttr("xmlns:ds", dsigNamespace)
+
+	canonicalizer := xmldsig.MakeC14N10ExclusiveCanonicalizerWithPrefixList("")
+	canonical, err := canonicalizer.Canonicalize(spCopy)
+	if err != nil {
+		return nil, err
+	}
+	hash := sha256.Sum256(canonical)
+	return hash[:], nil
+}
+
+// canonicalizeAndHash canonicalizes an element with exclusive C14N and returns its SHA-256 hash.
+func canonicalizeAndHash(el *etree.Element) ([]byte, error) {
+	canonicalizer := xmldsig.MakeC14N10ExclusiveCanonicalizerWithPrefixList("")
+	canonical, err := canonicalizer.Canonicalize(el)
+	if err != nil {
+		return nil, err
+	}
+	hash := sha256.Sum256(canonical)
+	return hash[:], nil
+}

--- a/pkg/dsig/xades.go
+++ b/pkg/dsig/xades.go
@@ -91,10 +91,12 @@ func SignXMLWithXAdES(xmlData []byte, signer crypto.Signer, cert *x509.Certifica
 }
 
 // generateSignatureID generates a deterministic-format signature ID.
-func generateSignatureID() string {
+func generateSignatureID() (string, error) {
 	b := make([]byte, 16)
-	_, _ = rand.Read(b)
-	return fmt.Sprintf("%x", b)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate signature ID: %w", err)
+	}
+	return fmt.Sprintf("%x", b), nil
 }
 
 // buildXAdESObject constructs the ds:Object element containing xades:QualifyingProperties.

--- a/pkg/dsig/xades.go
+++ b/pkg/dsig/xades.go
@@ -6,7 +6,9 @@ package dsig
 
 import (
 	"crypto"
+	"crypto/ecdsa"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
@@ -18,12 +20,13 @@ import (
 )
 
 const (
-	xadesNamespace      = "http://uri.etsi.org/01903/v1.3.2#"
-	dsigNamespace       = "http://www.w3.org/2000/09/xmldsig#"
-	excC14NAlgorithm    = "http://www.w3.org/2001/10/xml-exc-c14n#"
-	sha256DigestAlg     = "http://www.w3.org/2001/04/xmlenc#sha256"
-	envelopedSigAlg     = "http://www.w3.org/2000/09/xmldsig#enveloped-signature"
-	rsaSHA256SigAlg     = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+	xadesNamespace       = "http://uri.etsi.org/01903/v1.3.2#"
+	dsigNamespace        = "http://www.w3.org/2000/09/xmldsig#"
+	excC14NAlgorithm     = "http://www.w3.org/2001/10/xml-exc-c14n#"
+	sha256DigestAlg      = "http://www.w3.org/2001/04/xmlenc#sha256"
+	envelopedSigAlg      = "http://www.w3.org/2000/09/xmldsig#enveloped-signature"
+	rsaSHA256SigAlg      = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+	ecdsaSHA256SigAlg    = "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256"
 	signedPropertiesType = "http://uri.etsi.org/01903#SignedProperties"
 )
 
@@ -45,8 +48,17 @@ func SignXMLWithXAdES(xmlData []byte, signer crypto.Signer, cert *x509.Certifica
 
 	root := doc.Root()
 
+	// Determine signature algorithm from key type
+	sigAlgURI, err := signatureAlgorithmURI(cert.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+
 	// Generate a unique signature ID
-	sigID := generateSignatureID()
+	sigID, err := generateSignatureID()
+	if err != nil {
+		return nil, err
+	}
 	signedPropsID := "xades-" + sigID
 
 	// Build the QualifyingProperties / SignedProperties element
@@ -65,7 +77,7 @@ func SignXMLWithXAdES(xmlData []byte, signer crypto.Signer, cert *x509.Certifica
 	}
 
 	// Build SignedInfo with two references
-	signedInfo := buildSignedInfo(docDigest, signedPropsDigest, signedPropsID)
+	signedInfo := buildSignedInfo(docDigest, signedPropsDigest, signedPropsID, sigID, sigAlgURI)
 
 	// Canonicalize SignedInfo and sign it
 	signedInfoDigest, err := canonicalizeAndHash(signedInfo)
@@ -146,8 +158,20 @@ func buildXAdESObject(sigID, signedPropsID string, cert *x509.Certificate) *etre
 	return object
 }
 
+// signatureAlgorithmURI returns the XML-DSIG SignatureMethod URI for the given public key.
+func signatureAlgorithmURI(pub crypto.PublicKey) (string, error) {
+	switch pub.(type) {
+	case *rsa.PublicKey:
+		return rsaSHA256SigAlg, nil
+	case *ecdsa.PublicKey:
+		return ecdsaSHA256SigAlg, nil
+	default:
+		return "", fmt.Errorf("unsupported key type %T for XAdES signing", pub)
+	}
+}
+
 // buildSignedInfo constructs the ds:SignedInfo element with two references.
-func buildSignedInfo(docDigest, signedPropsDigest []byte, signedPropsID string) *etree.Element {
+func buildSignedInfo(docDigest, signedPropsDigest []byte, signedPropsID, sigID, sigAlgURI string) *etree.Element {
 	signedInfo := etree.NewElement("ds:SignedInfo")
 	signedInfo.CreateAttr("xmlns:ds", dsigNamespace)
 
@@ -157,10 +181,11 @@ func buildSignedInfo(docDigest, signedPropsDigest []byte, signedPropsID string) 
 
 	// SignatureMethod
 	sigMethod := signedInfo.CreateElement("ds:SignatureMethod")
-	sigMethod.CreateAttr("Algorithm", rsaSHA256SigAlg)
+	sigMethod.CreateAttr("Algorithm", sigAlgURI)
 
 	// Reference 1: the document
 	ref1 := signedInfo.CreateElement("ds:Reference")
+	ref1.CreateAttr("Id", "r-doc-"+sigID)
 	ref1.CreateAttr("URI", "")
 	transforms := ref1.CreateElement("ds:Transforms")
 	t1 := transforms.CreateElement("ds:Transform")

--- a/pkg/dsig/xades_test.go
+++ b/pkg/dsig/xades_test.go
@@ -1,0 +1,296 @@
+package dsig
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/beevik/etree"
+)
+
+// setupTestCert generates a self-signed certificate and key for testing.
+// Returns cert path, key path, and cleanup function.
+func setupTestCert(t *testing.T) (string, string) {
+	t.Helper()
+
+	if _, err := exec.LookPath("openssl"); err != nil {
+		t.Skip("Skipping test: openssl not available")
+	}
+
+	tmpDir := t.TempDir()
+	certPath := filepath.Join(tmpDir, "cert.pem")
+	keyPath := filepath.Join(tmpDir, "key.pem")
+
+	cmd := exec.Command("openssl", "req", "-x509", "-newkey", "rsa:2048",
+		"-keyout", keyPath, "-out", certPath, "-days", "1", "-nodes",
+		"-subj", "/CN=XAdES Test Certificate/O=Test Org")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Skipf("Failed to generate test certificate: %v, output: %s", err, output)
+	}
+
+	return certPath, keyPath
+}
+
+func TestFileSigner_XAdES_QualifyingProperties(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("Skipping XAdES test in CI environment")
+	}
+
+	certPath, keyPath := setupTestCert(t)
+
+	signer := NewFileSigner(certPath, keyPath)
+	// XAdES is on by default
+
+	xmlData := []byte(`<?xml version="1.0" encoding="UTF-8"?><TrustServiceStatusList xmlns="http://uri.etsi.org/02231/v2#"><SchemeInformation><TSLType>test</TSLType></SchemeInformation></TrustServiceStatusList>`)
+
+	signedData, err := signer.Sign(xmlData)
+	if err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+
+	doc := etree.NewDocument()
+	if err := doc.ReadFromBytes(signedData); err != nil {
+		t.Fatalf("Failed to parse signed XML: %v", err)
+	}
+
+	root := doc.Root()
+
+	// Verify ds:Signature exists
+	sig := root.FindElement("//ds:Signature")
+	if sig == nil {
+		sig = root.FindElement("//Signature")
+	}
+	if sig == nil {
+		t.Fatal("ds:Signature element not found in signed output")
+	}
+
+	// Verify QualifyingProperties
+	qp := sig.FindElement(".//xades:QualifyingProperties")
+	if qp == nil {
+		qp = sig.FindElement(".//QualifyingProperties")
+	}
+	if qp == nil {
+		t.Fatal("xades:QualifyingProperties not found")
+	}
+
+	// Verify Target attribute on QualifyingProperties
+	sigID := sig.SelectAttrValue("Id", "")
+	if sigID == "" {
+		t.Fatal("ds:Signature missing Id attribute")
+	}
+	target := qp.SelectAttrValue("Target", "")
+	if target != "#"+sigID {
+		t.Errorf("QualifyingProperties Target: got %q, want %q", target, "#"+sigID)
+	}
+
+	// Verify SignedProperties with Id
+	sp := qp.FindElement(".//xades:SignedProperties")
+	if sp == nil {
+		sp = qp.FindElement(".//SignedProperties")
+	}
+	if sp == nil {
+		t.Fatal("xades:SignedProperties not found")
+	}
+	spID := sp.SelectAttrValue("Id", "")
+	if spID == "" {
+		t.Fatal("xades:SignedProperties missing Id attribute")
+	}
+
+	// Verify SigningTime
+	sigTime := sp.FindElement(".//xades:SigningTime")
+	if sigTime == nil {
+		sigTime = sp.FindElement(".//SigningTime")
+	}
+	if sigTime == nil {
+		t.Fatal("xades:SigningTime not found")
+	}
+	if sigTime.Text() == "" {
+		t.Fatal("xades:SigningTime is empty")
+	}
+
+	// Verify SigningCertificate
+	sigCert := sp.FindElement(".//xades:SigningCertificate")
+	if sigCert == nil {
+		sigCert = sp.FindElement(".//SigningCertificate")
+	}
+	if sigCert == nil {
+		t.Fatal("xades:SigningCertificate not found")
+	}
+
+	// Verify CertDigest
+	certDigest := sigCert.FindElement(".//xades:CertDigest")
+	if certDigest == nil {
+		certDigest = sigCert.FindElement(".//CertDigest")
+	}
+	if certDigest == nil {
+		t.Fatal("xades:CertDigest not found")
+	}
+
+	// Verify DataObjectFormat
+	dof := sp.FindElement(".//xades:DataObjectFormat")
+	if dof == nil {
+		dof = sp.FindElement(".//DataObjectFormat")
+	}
+	if dof == nil {
+		t.Fatal("xades:DataObjectFormat not found")
+	}
+	mimeType := dof.FindElement(".//xades:MimeType")
+	if mimeType == nil {
+		mimeType = dof.FindElement(".//MimeType")
+	}
+	if mimeType == nil || mimeType.Text() != "text/xml" {
+		t.Error("xades:MimeType should be 'text/xml'")
+	}
+}
+
+func TestFileSigner_XAdES_TwoReferences(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("Skipping XAdES test in CI environment")
+	}
+
+	certPath, keyPath := setupTestCert(t)
+
+	signer := NewFileSigner(certPath, keyPath)
+
+	xmlData := []byte(`<Root><Data>test</Data></Root>`)
+	signedData, err := signer.Sign(xmlData)
+	if err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+
+	doc := etree.NewDocument()
+	if err := doc.ReadFromBytes(signedData); err != nil {
+		t.Fatalf("Failed to parse signed XML: %v", err)
+	}
+
+	// Find SignedInfo
+	si := doc.Root().FindElement("//ds:SignedInfo")
+	if si == nil {
+		si = doc.Root().FindElement("//SignedInfo")
+	}
+	if si == nil {
+		t.Fatal("ds:SignedInfo not found")
+	}
+
+	// Count references - XAdES-B-B requires exactly 2
+	refs := si.FindElements("ds:Reference")
+	if len(refs) == 0 {
+		refs = si.FindElements("Reference")
+	}
+	if len(refs) != 2 {
+		t.Fatalf("Expected 2 ds:Reference elements in SignedInfo (document + SignedProperties), got %d", len(refs))
+	}
+
+	// One reference should have empty URI (document), other should have Type=SignedProperties
+	var hasDocRef, hasPropsRef bool
+	for _, ref := range refs {
+		uri := ref.SelectAttrValue("URI", "none")
+		refType := ref.SelectAttrValue("Type", "")
+		if uri == "" {
+			hasDocRef = true
+		}
+		if refType == signedPropertiesType {
+			hasPropsRef = true
+		}
+	}
+
+	if !hasDocRef {
+		t.Error("Missing document reference (URI=\"\")")
+	}
+	if !hasPropsRef {
+		t.Errorf("Missing SignedProperties reference (Type=%q)", signedPropertiesType)
+	}
+}
+
+func TestFileSigner_XAdES_Disabled(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("Skipping XAdES test in CI environment")
+	}
+
+	certPath, keyPath := setupTestCert(t)
+
+	signer := NewFileSigner(certPath, keyPath)
+	signer.SetXAdES(false)
+
+	xmlData := []byte(`<Root><Data>test</Data></Root>`)
+	signedData, err := signer.Sign(xmlData)
+	if err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+
+	doc := etree.NewDocument()
+	if err := doc.ReadFromBytes(signedData); err != nil {
+		t.Fatalf("Failed to parse signed XML: %v", err)
+	}
+
+	signedStr := string(signedData)
+
+	// When XAdES is disabled, there should be no QualifyingProperties
+	if strings.Contains(signedStr, "QualifyingProperties") {
+		t.Error("XAdES disabled but QualifyingProperties found in output")
+	}
+	if strings.Contains(signedStr, "SignedProperties") {
+		t.Error("XAdES disabled but SignedProperties found in output")
+	}
+
+	// But there should still be a Signature
+	sig := doc.Root().FindElement("//Signature")
+	if sig == nil {
+		t.Fatal("No Signature found - plain XML-DSIG should still produce a signature")
+	}
+}
+
+func TestFileSigner_XAdES_CertDigestMatchesCert(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("Skipping XAdES test in CI environment")
+	}
+
+	certPath, keyPath := setupTestCert(t)
+
+	// Load the certificate to compute expected digest
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("Failed to read cert: %v", err)
+	}
+	block, _ := pem.Decode(certPEM)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse cert: %v", err)
+	}
+	expectedHash := sha256.Sum256(cert.Raw)
+	expectedDigest := base64.StdEncoding.EncodeToString(expectedHash[:])
+
+	signer := NewFileSigner(certPath, keyPath)
+
+	xmlData := []byte(`<Root><Data>test</Data></Root>`)
+	signedData, err := signer.Sign(xmlData)
+	if err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+
+	doc := etree.NewDocument()
+	if err := doc.ReadFromBytes(signedData); err != nil {
+		t.Fatalf("Failed to parse signed XML: %v", err)
+	}
+
+	// Find CertDigest/DigestValue
+	dv := doc.Root().FindElement("//xades:CertDigest/ds:DigestValue")
+	if dv == nil {
+		dv = doc.Root().FindElement("//CertDigest/DigestValue")
+	}
+	if dv == nil {
+		t.Fatal("CertDigest/DigestValue not found")
+	}
+
+	actualDigest := dv.Text()
+	if actualDigest != expectedDigest {
+		t.Errorf("CertDigest mismatch:\n  got:  %s\n  want: %s", actualDigest, expectedDigest)
+	}
+}

--- a/pkg/dsig/xades_test.go
+++ b/pkg/dsig/xades_test.go
@@ -1,40 +1,74 @@
 package dsig
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/pem"
+	"math/big"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/beevik/etree"
 )
 
 // setupTestCert generates a self-signed certificate and key for testing.
-// Returns cert path, key path, and cleanup function.
+// Returns cert path and key path.
 func setupTestCert(t *testing.T) (string, string) {
 	t.Helper()
-
-	if _, err := exec.LookPath("openssl"); err != nil {
-		t.Skip("Skipping test: openssl not available")
-	}
 
 	tmpDir := t.TempDir()
 	certPath := filepath.Join(tmpDir, "cert.pem")
 	keyPath := filepath.Join(tmpDir, "key.pem")
 
-	cmd := exec.Command("openssl", "req", "-x509", "-newkey", "rsa:2048",
-		"-keyout", keyPath, "-out", certPath, "-days", "1", "-nodes",
-		"-subj", "/CN=XAdES Test Certificate/O=Test Org")
-	output, err := cmd.CombinedOutput()
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		t.Skipf("Failed to generate test certificate: %v, output: %s", err, output)
+		t.Fatalf("failed to generate test private key: %v", err)
 	}
 
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		t.Fatalf("failed to generate certificate serial number: %v", err)
+	}
+
+	notBefore := time.Now().Add(-time.Hour)
+	notAfter := notBefore.Add(24 * time.Hour)
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   "XAdES Test Certificate",
+			Organization: []string{"Test Org"},
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		t.Fatalf("failed to create test certificate: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	if err := os.WriteFile(certPath, certPEM, 0644); err != nil {
+		t.Fatalf("failed to write test certificate: %v", err)
+	}
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		t.Fatalf("failed to write test private key: %v", err)
+	}
 	return certPath, keyPath
 }
 

--- a/pkg/dsig/xades_test.go
+++ b/pkg/dsig/xades_test.go
@@ -73,10 +73,6 @@ func setupTestCert(t *testing.T) (string, string) {
 }
 
 func TestFileSigner_XAdES_QualifyingProperties(t *testing.T) {
-	if os.Getenv("CI") == "true" {
-		t.Skip("Skipping XAdES test in CI environment")
-	}
-
 	certPath, keyPath := setupTestCert(t)
 
 	signer := NewFileSigner(certPath, keyPath)
@@ -185,10 +181,6 @@ func TestFileSigner_XAdES_QualifyingProperties(t *testing.T) {
 }
 
 func TestFileSigner_XAdES_TwoReferences(t *testing.T) {
-	if os.Getenv("CI") == "true" {
-		t.Skip("Skipping XAdES test in CI environment")
-	}
-
 	certPath, keyPath := setupTestCert(t)
 
 	signer := NewFileSigner(certPath, keyPath)
@@ -244,10 +236,6 @@ func TestFileSigner_XAdES_TwoReferences(t *testing.T) {
 }
 
 func TestFileSigner_XAdES_Disabled(t *testing.T) {
-	if os.Getenv("CI") == "true" {
-		t.Skip("Skipping XAdES test in CI environment")
-	}
-
 	certPath, keyPath := setupTestCert(t)
 
 	signer := NewFileSigner(certPath, keyPath)
@@ -282,10 +270,6 @@ func TestFileSigner_XAdES_Disabled(t *testing.T) {
 }
 
 func TestFileSigner_XAdES_CertDigestMatchesCert(t *testing.T) {
-	if os.Getenv("CI") == "true" {
-		t.Skip("Skipping XAdES test in CI environment")
-	}
-
 	certPath, keyPath := setupTestCert(t)
 
 	// Load the certificate to compute expected digest

--- a/pkg/jws/pkcs11_signer.go
+++ b/pkg/jws/pkcs11_signer.go
@@ -12,27 +12,36 @@ import (
 )
 
 // PKCS11Signer signs JSON payloads using a PKCS#11 hardware token.
+// By default it produces JAdES-B-B compliant signatures.
 type PKCS11Signer struct {
 	config    *crypto11.Config
 	context   *crypto11.Context
 	keyLabel  string
 	certLabel string
 	keyID     string
+	jades     bool // JAdES-B-B compliance (default: true)
 }
 
 // NewPKCS11Signer creates a JWS signer backed by a PKCS#11 HSM.
+// JAdES-B-B compliance is enabled by default.
 func NewPKCS11Signer(config *crypto11.Config, keyLabel, certLabel string) *PKCS11Signer {
 	return &PKCS11Signer{
 		config:    config,
 		keyLabel:  keyLabel,
 		certLabel: certLabel,
 		keyID:     "01",
+		jades:     true,
 	}
 }
 
 // SetKeyID sets the hex ID for key and certificate lookups.
 func (s *PKCS11Signer) SetKeyID(id string) {
 	s.keyID = id
+}
+
+// SetJAdES enables or disables JAdES-B-B compliant headers (sigT, x5t#S256).
+func (s *PKCS11Signer) SetJAdES(enabled bool) {
+	s.jades = enabled
 }
 
 // Sign produces a compact JWS serialization of the payload using the HSM key.
@@ -66,6 +75,10 @@ func (s *PKCS11Signer) Sign(payload []byte) (string, error) {
 	signingKey := jose.SigningKey{Algorithm: alg, Key: privateKey}
 	opts := &jose.SignerOptions{}
 	opts.WithHeader("x5c", [][]byte{cert.Raw})
+
+	if s.jades {
+		addJAdESHeaders(opts, cert)
+	}
 
 	signer, err := jose.NewSigner(signingKey, opts)
 	if err != nil {

--- a/pkg/jws/signer.go
+++ b/pkg/jws/signer.go
@@ -2,6 +2,10 @@
 //
 // This complements the XML-DSIG signing in pkg/dsig by providing JWS-based
 // integrity protection as required by ETSI TS 119 602.
+//
+// By default, signatures are produced in JAdES-B-B profile (ETSI TS 119 182-1),
+// which adds sigT (signing time) and x5t#S256 (certificate thumbprint) headers
+// to the standard JWS protected header.
 package jws
 
 import (
@@ -9,10 +13,13 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"os"
+	"time"
 
 	jose "github.com/go-jose/go-jose/v4"
 )
@@ -22,17 +29,27 @@ type JSONSigner interface {
 	Sign(payload []byte) (string, error)
 }
 
+// JAdESConfigurable allows configuring JAdES compliance on a signer.
+type JAdESConfigurable interface {
+	SetJAdES(enabled bool)
+}
+
 // JSONVerifier verifies JWS compact serializations.
 type JSONVerifier interface {
 	Verify(compact string) ([]byte, error)
 }
 
 // FileSigner signs using a PEM-encoded private key and certificate file.
+// By default it produces JAdES-B-B compliant signatures.
 type FileSigner struct {
-	signer jose.Signer
+	key   crypto.PrivateKey
+	certs []*x509.Certificate
+	alg   jose.SignatureAlgorithm
+	jades bool // JAdES-B-B compliance (default: true)
 }
 
 // NewFileSigner creates a JWS signer from PEM certificate and private key files.
+// JAdES-B-B compliance is enabled by default.
 func NewFileSigner(certFile, keyFile string) (*FileSigner, error) {
 	keyPEM, err := os.ReadFile(keyFile)
 	if err != nil {
@@ -59,25 +76,49 @@ func NewFileSigner(certFile, keyFile string) (*FileSigner, error) {
 		return nil, err
 	}
 
-	signingKey := jose.SigningKey{Algorithm: alg, Key: key}
-	opts := &jose.SignerOptions{}
-	opts.WithHeader("x5c", certsToX5C(certs))
+	return &FileSigner{
+		key:   key,
+		certs: certs,
+		alg:   alg,
+		jades: true,
+	}, nil
+}
 
-	signer, err := jose.NewSigner(signingKey, opts)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create JWS signer: %w", err)
-	}
-
-	return &FileSigner{signer: signer}, nil
+// SetJAdES enables or disables JAdES-B-B compliant headers (sigT, x5t#S256).
+func (s *FileSigner) SetJAdES(enabled bool) {
+	s.jades = enabled
 }
 
 // Sign produces a compact JWS serialization of the payload.
 func (s *FileSigner) Sign(payload []byte) (string, error) {
-	obj, err := s.signer.Sign(payload)
+	signingKey := jose.SigningKey{Algorithm: s.alg, Key: s.key}
+	opts := &jose.SignerOptions{}
+	opts.WithHeader("x5c", certsToX5C(s.certs))
+
+	if s.jades {
+		addJAdESHeaders(opts, s.certs[0])
+	}
+
+	signer, err := jose.NewSigner(signingKey, opts)
+	if err != nil {
+		return "", fmt.Errorf("failed to create JWS signer: %w", err)
+	}
+
+	obj, err := signer.Sign(payload)
 	if err != nil {
 		return "", fmt.Errorf("JWS signing failed: %w", err)
 	}
 	return obj.CompactSerialize()
+}
+
+// addJAdESHeaders adds ETSI TS 119 182-1 JAdES-B-B required headers to the signer options.
+func addJAdESHeaders(opts *jose.SignerOptions, cert *x509.Certificate) {
+	// sigT: signing time as RFC 3339 UTC (ETSI TS 119 182-1 §5.2.8)
+	opts.WithHeader("sigT", time.Now().UTC().Format(time.RFC3339))
+
+	// x5t#S256: SHA-256 thumbprint of the signing certificate (ETSI TS 119 182-1 §5.2.2)
+	thumbprint := sha256.Sum256(cert.Raw)
+	opts.WithHeader("x5t#S256", base64.RawURLEncoding.EncodeToString(thumbprint[:]))
 }
 
 // KeyVerifier verifies JWS using a set of trusted public keys.

--- a/pkg/jws/signer_test.go
+++ b/pkg/jws/signer_test.go
@@ -5,8 +5,10 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/pem"
 	"math/big"
 	"os"
@@ -14,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	jose "github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -181,4 +184,99 @@ func parseCertFile(path string) (*x509.Certificate, error) {
 		return nil, err
 	}
 	return certs[0], nil
+}
+
+func TestFileSigner_JAdES_Headers(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := generateTestCertAndKey(t, dir, "ec256")
+
+	signer, err := NewFileSigner(certPath, keyPath)
+	require.NoError(t, err)
+
+	payload := []byte(`{"test": "jades"}`)
+	compact, err := signer.Sign(payload)
+	require.NoError(t, err)
+
+	// Parse the JWS to inspect headers
+	parsed, err := jose.ParseSigned(compact, []jose.SignatureAlgorithm{jose.ES256})
+	require.NoError(t, err)
+	require.Len(t, parsed.Signatures, 1)
+
+	headers := parsed.Signatures[0].Protected
+	// sigT must be present and be a valid RFC 3339 timestamp
+	sigT, ok := headers.ExtraHeaders["sigT"]
+	assert.True(t, ok, "sigT header must be present for JAdES-B-B")
+	sigTStr, ok := sigT.(string)
+	assert.True(t, ok, "sigT must be a string")
+	_, err = time.Parse(time.RFC3339, sigTStr)
+	assert.NoError(t, err, "sigT must be valid RFC 3339")
+
+	// x5t#S256 must be present
+	thumbprint, ok := headers.ExtraHeaders["x5t#S256"]
+	assert.True(t, ok, "x5t#S256 header must be present for JAdES-B-B")
+	assert.NotEmpty(t, thumbprint)
+
+	// Verify the JWS still verifies correctly
+	cert, err := parseCertFile(certPath)
+	require.NoError(t, err)
+	verifier := NewCertVerifier(cert)
+	verified, err := verifier.Verify(compact)
+	require.NoError(t, err)
+	assert.Equal(t, payload, verified)
+}
+
+func TestFileSigner_JAdES_Disabled(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := generateTestCertAndKey(t, dir, "rsa")
+
+	signer, err := NewFileSigner(certPath, keyPath)
+	require.NoError(t, err)
+	signer.SetJAdES(false)
+
+	payload := []byte(`{"test": "plain"}`)
+	compact, err := signer.Sign(payload)
+	require.NoError(t, err)
+
+	// Parse the JWS to inspect headers
+	parsed, err := jose.ParseSigned(compact, []jose.SignatureAlgorithm{jose.RS256})
+	require.NoError(t, err)
+	require.Len(t, parsed.Signatures, 1)
+
+	headers := parsed.Signatures[0].Protected
+	_, hasSigT := headers.ExtraHeaders["sigT"]
+	assert.False(t, hasSigT, "sigT must not be present when JAdES is disabled")
+	_, hasThumb := headers.ExtraHeaders["x5t#S256"]
+	assert.False(t, hasThumb, "x5t#S256 must not be present when JAdES is disabled")
+
+	// Verify still works
+	cert, err := parseCertFile(certPath)
+	require.NoError(t, err)
+	verifier := NewCertVerifier(cert)
+	verified, err := verifier.Verify(compact)
+	require.NoError(t, err)
+	assert.Equal(t, payload, verified)
+}
+
+func TestFileSigner_JAdES_Thumbprint_Matches_Cert(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := generateTestCertAndKey(t, dir, "ec256")
+
+	signer, err := NewFileSigner(certPath, keyPath)
+	require.NoError(t, err)
+
+	compact, err := signer.Sign([]byte("test"))
+	require.NoError(t, err)
+
+	// Parse the JWS
+	parsed, err := jose.ParseSigned(compact, []jose.SignatureAlgorithm{jose.ES256})
+	require.NoError(t, err)
+
+	// Compute expected thumbprint from cert
+	cert, err := parseCertFile(certPath)
+	require.NoError(t, err)
+	expectedThumbprint := sha256.Sum256(cert.Raw)
+	expectedB64 := base64.RawURLEncoding.EncodeToString(expectedThumbprint[:])
+
+	actual := parsed.Signatures[0].Protected.ExtraHeaders["x5t#S256"]
+	assert.Equal(t, expectedB64, actual, "x5t#S256 must match SHA-256 of signing cert DER")
 }

--- a/pkg/pipeline/step_publish.go
+++ b/pkg/pipeline/step_publish.go
@@ -37,11 +37,24 @@ import (
 //
 // Example usage in pipeline configuration:
 //   - publish:/path/to/output/dir  # Publish all TSLs to the specified directory
-//   - publish:["/path/to/output/dir", "/path/to/cert.pem", "/path/to/key.pem"]  # With XML-DSIG signatures
+//   - publish:["/path/to/output/dir", "/path/to/cert.pem", "/path/to/key.pem"]  # With XAdES signatures (default)
+//   - publish:["/path/to/output/dir", "/path/to/cert.pem", "/path/to/key.pem", "xades:false"]  # Plain XML-DSIG
 func PublishTSL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 	if len(args) < 1 {
 		return ctx, fmt.Errorf("missing argument: directory path")
 	}
+
+	// Check for xades:false in any argument position and filter it out
+	xadesEnabled := true
+	var filteredArgs []string
+	for _, arg := range args {
+		if arg == "xades:false" {
+			xadesEnabled = false
+		} else {
+			filteredArgs = append(filteredArgs, arg)
+		}
+	}
+	args = filteredArgs
 
 	dirPath := args[0]
 
@@ -62,7 +75,9 @@ func PublishTSL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 		if err := validation.ValidateFilePath(args[2]); err != nil {
 			return ctx, fmt.Errorf("invalid key path: %w", err)
 		}
-		signer = dsig.NewFileSigner(args[1], args[2])
+		fs := dsig.NewFileSigner(args[1], args[2])
+		fs.SetXAdES(xadesEnabled)
+		signer = fs
 	}
 
 	// Check if this is a PKCS#11 signer configuration
@@ -86,6 +101,7 @@ func PublishTSL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 			}
 			pkcs11Signer := dsig.NewPKCS11Signer(pkcs11Config, keyLabel, certLabel)
 			pkcs11Signer.SetKeyID(keyID)
+			pkcs11Signer.SetXAdES(xadesEnabled)
 			signer = pkcs11Signer
 		}
 	}

--- a/pkg/pipeline/step_publish.go
+++ b/pkg/pipeline/step_publish.go
@@ -56,6 +56,9 @@ func PublishTSL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 	}
 	args = filteredArgs
 
+	if len(args) < 1 {
+		return ctx, fmt.Errorf("missing argument: directory path")
+	}
 	dirPath := args[0]
 
 	// Validate output directory before processing

--- a/pkg/pipeline/step_publish_lote.go
+++ b/pkg/pipeline/step_publish_lote.go
@@ -17,14 +17,19 @@ import (
 // PublishLoTE writes LoTE documents from ctx.LoTEs to JSON files,
 // optionally signing them with JWS.
 //
+// By default, signatures use JAdES-B-B profile (ETSI TS 119 182-1).
+// Pass "jades:false" as an argument to disable JAdES headers and produce plain JWS.
+//
 // Usage in pipeline YAML:
 //
 //   - publish-lote:
 //   - /path/to/output/dir                                              # unsigned JSON
 //   - publish-lote:
-//   - ["/path/to/dir", "/cert.pem", "/key.pem"]                       # JWS-signed with file key
+//   - ["/path/to/dir", "/cert.pem", "/key.pem"]                       # JAdES-signed (default)
 //   - publish-lote:
-//   - ["/path/to/dir", "pkcs11:module=/path;pin=1234", "key", "cert"] # JWS-signed with PKCS#11
+//   - ["/path/to/dir", "/cert.pem", "/key.pem", "jades:false"]        # plain JWS
+//   - publish-lote:
+//   - ["/path/to/dir", "pkcs11:module=/path;pin=1234", "key", "cert"] # JAdES-signed with PKCS#11
 func PublishLoTE(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 	if len(args) < 1 {
 		return nil, fmt.Errorf("publish-lote requires at least 1 argument: output directory")
@@ -130,7 +135,24 @@ func loteFilename(lote *etsi119602.ListOfTrustedEntities, index int) string {
 
 // createLoTESigner creates a JWS signer from the remaining publish-lote arguments.
 // Returns nil signer if no signing args provided.
+// Supports "jades:false" argument to disable JAdES-B-B headers.
 func createLoTESigner(args []string) (jws.JSONSigner, error) {
+	if len(args) == 0 {
+		return nil, nil
+	}
+
+	// Check for jades:false in any argument position and filter it out
+	jadesEnabled := true
+	var filteredArgs []string
+	for _, arg := range args {
+		if arg == "jades:false" {
+			jadesEnabled = false
+		} else {
+			filteredArgs = append(filteredArgs, arg)
+		}
+	}
+	args = filteredArgs
+
 	if len(args) == 0 {
 		return nil, nil
 	}
@@ -153,6 +175,7 @@ func createLoTESigner(args []string) (jws.JSONSigner, error) {
 		if len(args) >= 4 {
 			signer.SetKeyID(args[3])
 		}
+		signer.SetJAdES(jadesEnabled)
 		return signer, nil
 	}
 
@@ -162,6 +185,7 @@ func createLoTESigner(args []string) (jws.JSONSigner, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create JWS signer: %w", err)
 		}
+		s.SetJAdES(jadesEnabled)
 		return s, nil
 	}
 


### PR DESCRIPTION
## Summary

Implements ETSI signature standards for both LoTE (JWS) and TSL (XML) outputs, ensuring g119612 produces compliant digital signatures.

### JAdES-B-B (ETSI TS 119 182-1) — LoTE/JWS signing

- **`sigT`**: Signing time (RFC 3339 UTC) in JWS protected header
- **`x5t#S256`**: SHA-256 certificate thumbprint (base64url) in JWS protected header
- Refactored `FileSigner` to create `jose.Signer` per-sign for header injection
- `SetJAdES(bool)` on both `FileSigner` and `PKCS11Signer` (default: `true`)
- Pipeline: `publish-lote` accepts `jades:false` arg to disable

### XAdES-B-B (ETSI TS 101 903 / EN 319 132-1) — TSL/XML signing

- New `SignXMLWithXAdES()` with full `QualifyingProperties` envelope
- `SignedProperties` includes:
  - `SigningTime`
  - `SigningCertificate` (`CertDigest` SHA-256 + `IssuerSerial`)
  - `DataObjectFormat` (`MimeType text/xml`)
- Two `ds:Reference` elements: document + `SignedProperties`
- `SetXAdES(bool)` on both `FileSigner` and `PKCS11Signer` (default: `true`)
- Pipeline: `publish` accepts `xades:false` arg to disable

### Tests

- 3 JAdES tests: header presence, disabled mode, thumbprint verification
- 4 XAdES tests: QualifyingProperties structure, two References, disabled mode, CertDigest verification
- Full test suite passing

### Files changed

| File | Change |
|------|--------|
| `pkg/jws/signer.go` | JAdES header injection, refactored FileSigner |
| `pkg/jws/pkcs11_signer.go` | JAdES support for HSM signing |
| `pkg/jws/signer_test.go` | 3 new JAdES tests |
| `pkg/dsig/xades.go` | **New** — XAdES-B-B signing implementation |
| `pkg/dsig/xades_test.go` | **New** — 4 XAdES tests |
| `pkg/dsig/file_signer.go` | XAdES routing + config |
| `pkg/dsig/pkcs11_signer.go` | XAdES routing + config |
| `pkg/dsig/signer.go` | `XAdESConfigurable` interface |
| `pkg/pipeline/step_publish.go` | `xades:false` pipeline arg |
| `pkg/pipeline/step_publish_lote.go` | `jades:false` pipeline arg |