### PR TITLE
feat: add fetch resilience with retry, body limits, and context support

### DIFF
--- a/pkg/etsi119602/fetch.go
+++ b/pkg/etsi119602/fetch.go
@@ -247,20 +247,26 @@ func fetchRawWithContentType(url string, opts *FetchOptions, accept string) ([]b
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
 	retryCfg := resilience.Config{
 		MaxAttempts:    maxAttempts,
 		RetryBaseDelay: retryBaseDelay,
 		MaxBodyBytes:   maxBody,
-	}
+	}.WithDefaults()
+
+	// Overall context accounts for all attempts + backoff.
+	overallTimeout := timeout * time.Duration(retryCfg.MaxAttempts) * 2
+	ctx, cancel := context.WithTimeout(context.Background(), overallTimeout)
+	defer cancel()
 
 	var body []byte
 	var ct string
 
 	err := resilience.DoWithRetry(ctx, retryCfg, func() error {
-		req, reqErr := http.NewRequestWithContext(ctx, "GET", url, nil)
+		// Per-attempt context so a single timeout doesn't exhaust the overall deadline.
+		attemptCtx, attemptCancel := context.WithTimeout(ctx, timeout)
+		defer attemptCancel()
+
+		req, reqErr := http.NewRequestWithContext(attemptCtx, "GET", url, nil)
 		if reqErr != nil {
 			return fmt.Errorf("failed to create request for %s: %w", url, reqErr)
 		}

--- a/pkg/etsi119602/fetch.go
+++ b/pkg/etsi119602/fetch.go
@@ -2,6 +2,7 @@ package etsi119602
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/sirosfoundation/g119612/pkg/resilience"
 )
 
 // FetchOptions configures how LoTEs are fetched.
@@ -21,6 +24,19 @@ type FetchOptions struct {
 
 	// HTTPClient allows injecting a custom client (e.g., for testing).
 	HTTPClient *http.Client
+
+	// MaxAttempts is the maximum number of fetch attempts per URL (1 = no retry).
+	// Transient failures (transport errors, 5xx) are retried with exponential
+	// backoff; 4xx and parse errors fail immediately. Default: 3.
+	MaxAttempts int
+
+	// RetryBaseDelay is the initial backoff duration; doubled after each retry.
+	// Default: 500ms.
+	RetryBaseDelay time.Duration
+
+	// MaxBodyBytes limits the response body size. Returns an error if the
+	// response exceeds this limit. Default: 10MB.
+	MaxBodyBytes int64
 }
 
 // JWSVerifier verifies JWS compact serializations and returns the payload.
@@ -210,55 +226,91 @@ func fetchRawFromURL(url string, opts *FetchOptions, accept string) ([]byte, err
 
 func fetchRawWithContentType(url string, opts *FetchOptions, accept string) ([]byte, string, error) {
 	client := &http.Client{Timeout: 30 * time.Second}
+	timeout := 30 * time.Second
+	var maxAttempts int
+	var retryBaseDelay time.Duration
+	var maxBody int64 = 10 * 1024 * 1024 // 10MB default
+
 	if opts != nil {
 		if opts.HTTPClient != nil {
 			client = opts.HTTPClient
 		} else if opts.Timeout > 0 {
 			client.Timeout = opts.Timeout
 		}
+		if opts.Timeout > 0 {
+			timeout = opts.Timeout
+		}
+		maxAttempts = opts.MaxAttempts
+		retryBaseDelay = opts.RetryBaseDelay
+		if opts.MaxBodyBytes > 0 {
+			maxBody = opts.MaxBodyBytes
+		}
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	retryCfg := resilience.Config{
+		MaxAttempts:    maxAttempts,
+		RetryBaseDelay: retryBaseDelay,
+		MaxBodyBytes:   maxBody,
+	}
+
+	var body []byte
+	var ct string
+
+	err := resilience.DoWithRetry(ctx, retryCfg, func() error {
+		req, reqErr := http.NewRequestWithContext(ctx, "GET", url, nil)
+		if reqErr != nil {
+			return fmt.Errorf("failed to create request for %s: %w", url, reqErr)
+		}
+		req.Header.Set("Accept", accept)
+		if opts != nil && opts.UserAgent != "" {
+			req.Header.Set("User-Agent", opts.UserAgent)
+		}
+
+		resp, doErr := client.Do(req)
+		if doErr != nil {
+			return &resilience.TransportError{Err: fmt.Errorf("failed to fetch from %s: %w", url, doErr)}
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return &resilience.HTTPStatusError{StatusCode: resp.StatusCode, URL: url}
+		}
+
+		ct = ""
+		if raw := resp.Header.Get("Content-Type"); raw != "" {
+			ct = strings.ToLower(strings.TrimSpace(strings.SplitN(raw, ";", 2)[0]))
+		}
+
+		// Reject clearly wrong content types
+		allowedTypes := map[string]bool{
+			"application/json":         true,
+			"application/jose":         true,
+			"application/xml":          true,
+			"text/xml":                 true,
+			"text/plain":               true,
+			"application/octet-stream": true,
+			"":                         true,
+		}
+		if !allowedTypes[ct] {
+			return fmt.Errorf("unexpected Content-Type %q fetching %s", ct, url)
+		}
+
+		body, doErr = io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
+		if doErr != nil {
+			return &resilience.TransportError{Err: fmt.Errorf("failed to read response from %s: %w", url, doErr)}
+		}
+		if int64(len(body)) > maxBody {
+			return fmt.Errorf("response body from %s exceeds maximum size of %d bytes", url, maxBody)
+		}
+
+		return nil
+	})
+
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to create request for %s: %w", url, err)
-	}
-	req.Header.Set("Accept", accept)
-	if opts != nil && opts.UserAgent != "" {
-		req.Header.Set("User-Agent", opts.UserAgent)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to fetch from %s: %w", url, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, "", fmt.Errorf("unexpected status %d fetching %s", resp.StatusCode, url)
-	}
-
-	ct := ""
-	if raw := resp.Header.Get("Content-Type"); raw != "" {
-		ct = strings.ToLower(strings.TrimSpace(strings.SplitN(raw, ";", 2)[0]))
-	}
-
-	// Reject clearly wrong content types
-	allowedTypes := map[string]bool{
-		"application/json":         true,
-		"application/jose":         true,
-		"application/xml":          true,
-		"text/xml":                 true,
-		"text/plain":               true,
-		"application/octet-stream": true,
-		"":                         true,
-	}
-	if !allowedTypes[ct] {
-		return nil, "", fmt.Errorf("unexpected Content-Type %q fetching %s", ct, url)
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024)) // 10MB limit
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to read response from %s: %w", url, err)
+		return nil, "", err
 	}
 
 	return body, ct, nil

--- a/pkg/etsi119602/xmltypes/1960201_xsd_schema.xsd.go
+++ b/pkg/etsi119602/xmltypes/1960201_xsd_schema.xsd.go
@@ -9,13 +9,13 @@ type InternationalNamesType struct {
 
 // MultiLangNormStringType ...
 type MultiLangNormStringType struct {
-	XmlLangAttr *Lang `xml:"lang,attr"`
+	XmlLangAttr               *Lang `xml:"lang,attr"`
 	*NonEmptyNormalizedString `xml:",chardata"`
 }
 
 // MultiLangStringType ...
 type MultiLangStringType struct {
-	XmlLangAttr *Lang `xml:"lang,attr"`
+	XmlLangAttr     *Lang `xml:"lang,attr"`
 	*NonEmptyString `xml:",chardata"`
 }
 

--- a/pkg/etsi119612/19612_xsd.xsd.go
+++ b/pkg/etsi119612/19612_xsd.xsd.go
@@ -9,13 +9,13 @@ type InternationalNamesType struct {
 
 // MultiLangNormStringType ...
 type MultiLangNormStringType struct {
-	XmlLangAttr *Lang `xml:"lang,attr"`
+	XmlLangAttr               *Lang `xml:"lang,attr"`
 	*NonEmptyNormalizedString `xml:",chardata"`
 }
 
 // MultiLangStringType ...
 type MultiLangStringType struct {
-	XmlLangAttr *Lang `xml:"lang,attr"`
+	XmlLangAttr     *Lang `xml:"lang,attr"`
 	*NonEmptyString `xml:",chardata"`
 }
 

--- a/pkg/etsi119612/tsl.go
+++ b/pkg/etsi119612/tsl.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/moov-io/signedxml"
+	"github.com/sirosfoundation/g119612/pkg/resilience"
 	"github.com/sirosfoundation/go-cryptoutil"
 )
 
@@ -114,6 +115,19 @@ type TSLFetchOptions struct {
 	// This allows the caller to collect fetch errors for reporting.
 	// If nil, errors are only logged.
 	FetchErrorCallback func(url string, err error)
+
+	// MaxAttempts is the maximum number of fetch attempts per URL (1 = no retry).
+	// Transient failures (transport errors, 5xx) are retried with exponential
+	// backoff; 4xx and parse errors fail immediately. Default: 3.
+	MaxAttempts int
+
+	// RetryBaseDelay is the initial backoff duration; doubled after each retry.
+	// Default: 500ms.
+	RetryBaseDelay time.Duration
+
+	// MaxBodyBytes limits the response body size. Returns an error if the
+	// response exceeds this limit. Default: 10MB.
+	MaxBodyBytes int64
 }
 
 // DefaultTSLFetchOptions provides reasonable default options for fetching TSLs
@@ -187,36 +201,58 @@ func FetchTSLWithOptions(url string, options TSLFetchOptions) (*TSL, error) {
 			}
 		}
 
-		// Create request with context
+		// Determine body size limit
+		maxBody := options.MaxBodyBytes
+		if maxBody <= 0 {
+			maxBody = 10 << 20 // 10 MB default
+		}
+
+		// Create a context for the overall fetch (including retries)
 		ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
 		defer cancel()
 
-		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-		if err != nil {
-			return nil, err
+		retryCfg := resilience.Config{
+			MaxAttempts:    options.MaxAttempts,
+			RetryBaseDelay: options.RetryBaseDelay,
+			MaxBodyBytes:   maxBody,
 		}
 
-		// Set User-Agent header
-		req.Header.Set("User-Agent", options.UserAgent)
+		err = resilience.DoWithRetry(ctx, retryCfg, func() error {
+			req, reqErr := http.NewRequestWithContext(ctx, "GET", url, nil)
+			if reqErr != nil {
+				return reqErr
+			}
 
-		// Set Accept headers for content negotiation
-		if len(options.AcceptHeaders) > 0 {
-			req.Header.Set("Accept", strings.Join(options.AcceptHeaders, ", "))
-		}
+			// Set User-Agent header
+			req.Header.Set("User-Agent", options.UserAgent)
 
-		// Execute request
-		resp, err := client.Do(req)
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
+			// Set Accept headers for content negotiation
+			if len(options.AcceptHeaders) > 0 {
+				req.Header.Set("Accept", strings.Join(options.AcceptHeaders, ", "))
+			}
 
-		// Check response status
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("unexpected HTTP status: %s", resp.Status)
-		}
+			// Execute request
+			resp, doErr := client.Do(req)
+			if doErr != nil {
+				return &resilience.TransportError{Err: doErr}
+			}
+			defer resp.Body.Close()
 
-		bodyBytes, err = io.ReadAll(resp.Body)
+			// Check response status
+			if resp.StatusCode != http.StatusOK {
+				return &resilience.HTTPStatusError{StatusCode: resp.StatusCode, URL: url}
+			}
+
+			bodyBytes, doErr = io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
+			if doErr != nil {
+				return &resilience.TransportError{Err: fmt.Errorf("reading body: %w", doErr)}
+			}
+			if int64(len(bodyBytes)) > maxBody {
+				return fmt.Errorf("response body from %s exceeds maximum size of %d bytes", url, maxBody)
+			}
+			return nil
+		})
+
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/etsi119612/tsl.go
+++ b/pkg/etsi119612/tsl.go
@@ -207,18 +207,27 @@ func FetchTSLWithOptions(url string, options TSLFetchOptions) (*TSL, error) {
 			maxBody = 10 << 20 // 10 MB default
 		}
 
-		// Create a context for the overall fetch (including retries)
-		ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
-		defer cancel()
-
 		retryCfg := resilience.Config{
 			MaxAttempts:    options.MaxAttempts,
 			RetryBaseDelay: options.RetryBaseDelay,
 			MaxBodyBytes:   maxBody,
+		}.WithDefaults()
+
+		// Overall context accounts for all attempts + backoff.
+		perAttemptTimeout := options.Timeout
+		if perAttemptTimeout <= 0 {
+			perAttemptTimeout = 30 * time.Second
 		}
+		overallTimeout := perAttemptTimeout * time.Duration(retryCfg.MaxAttempts) * 2
+		ctx, cancel := context.WithTimeout(context.Background(), overallTimeout)
+		defer cancel()
 
 		err = resilience.DoWithRetry(ctx, retryCfg, func() error {
-			req, reqErr := http.NewRequestWithContext(ctx, "GET", url, nil)
+			// Per-attempt context so a single timeout doesn't exhaust the overall deadline.
+			attemptCtx, attemptCancel := context.WithTimeout(ctx, perAttemptTimeout)
+			defer attemptCancel()
+
+			req, reqErr := http.NewRequestWithContext(attemptCtx, "GET", url, nil)
 			if reqErr != nil {
 				return reqErr
 			}

--- a/pkg/etsi119612/tsl_coverage_test.go
+++ b/pkg/etsi119612/tsl_coverage_test.go
@@ -197,11 +197,11 @@ func generateTestCert119612(t *testing.T, cn string) *x509.Certificate {
 	require.NoError(t, err)
 
 	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: cn},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(24 * time.Hour),
-		IsCA:         true,
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
 		BasicConstraintsValid: true,
 	}
 	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)

--- a/pkg/etsi119612/tsl_test.go
+++ b/pkg/etsi119612/tsl_test.go
@@ -140,10 +140,11 @@ func TestFetchTSLWithOptions_Timeout(t *testing.T) {
 		Delay(200 * time.Millisecond). // Delay the response
 		File("./testdata/EWC-TL.xml")
 
-	// Use very short timeout (50ms)
+	// Use very short timeout (50ms) with no retries
 	options := etsi119612.TSLFetchOptions{
-		UserAgent: "TimeoutTest/1.0",
-		Timeout:   50 * time.Millisecond,
+		UserAgent:   "TimeoutTest/1.0",
+		Timeout:     50 * time.Millisecond,
+		MaxAttempts: 1,
 	}
 
 	// This should time out

--- a/pkg/etsi119612/tsl_test.go
+++ b/pkg/etsi119612/tsl_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirosfoundation/g119612/pkg/etsi119612"
 	"github.com/h2non/gock"
+	"github.com/sirosfoundation/g119612/pkg/etsi119612"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/etsi119612/x5c_validation_test.go
+++ b/pkg/etsi119612/x5c_validation_test.go
@@ -1,37 +1,36 @@
 package etsi119612_test
 
 import (
-	"testing"
-	"os"
-	"github.com/sirosfoundation/g119612/pkg/etsi119612"
-	"github.com/h2non/gock"
-	"github.com/stretchr/testify/assert"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"encoding/base64"
-	"crypto/x509"
+	"github.com/h2non/gock"
+	"github.com/sirosfoundation/g119612/pkg/etsi119612"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
 )
 
 type JWTCertBundle struct {
-	Alg string `json:"alg"`
-	Typ string `json:"typ"`
+	Alg string   `json:"alg"`
+	Typ string   `json:"typ"`
 	X5c []string `json:"x5c"`
-
 }
 
 func TestLeafRootCertVerificationSuccess(t *testing.T) {
-	header_mock, err:= os.ReadFile("./testdata/x5c-test-root-leaf.json")
+	header_mock, err := os.ReadFile("./testdata/x5c-test-root-leaf.json")
 	if err != nil {
 		t.Fatalf("Failed while reading json: %v", err)
 	}
-    assert.NotEmpty(t, header_mock) 
+	assert.NotEmpty(t, header_mock)
 	var jwt JWTCertBundle
-	err =json.Unmarshal(header_mock, &jwt)
-	if err !=nil{
+	err = json.Unmarshal(header_mock, &jwt)
+	if err != nil {
 		t.Fatalf("Failed updating jwt bundle")
 	}
 	assert.NotEmpty(t, jwt)
-	assert.NotEmpty(t, jwt.Alg) 
+	assert.NotEmpty(t, jwt.Alg)
 	assert.NotEmpty(t, jwt.Typ)
 	assert.NotEmpty(t, jwt.X5c)
 	defer gock.Off()
@@ -40,19 +39,19 @@ func TestLeafRootCertVerificationSuccess(t *testing.T) {
 		Reply(200).
 		File("testdata/test-trust-list-no-sig.xml")
 	tsl, err := etsi119612.FetchTSL("https://ewc-consortium.github.io/ewc-trust-list/EWC-TL")
-	assert.NoError(t,err)
-	policy := *etsi119612.PolicyAll 
+	assert.NoError(t, err)
+	policy := *etsi119612.PolicyAll
 	policy.AddServiceTypeIdentifier("http://uri.etsi.org/TrstSvc/Svctype/CA/QC")
 	pool := tsl.ToCertPool(&policy)
 	fmt.Println("Number of trusted roots:", len(pool.Subjects()))
 	assert.NotNil(t, pool)
-	leafDER, err:= base64.StdEncoding.DecodeString(jwt.X5c[0])
-	assert.NoError(t,err)
+	leafDER, err := base64.StdEncoding.DecodeString(jwt.X5c[0])
+	assert.NoError(t, err)
 	leafCert, err := x509.ParseCertificate(leafDER)
-	assert.NoError(t,err)
+	assert.NoError(t, err)
 	_, err = leafCert.Verify(x509.VerifyOptions{
-    Roots: pool})
-	if err !=nil {
+		Roots: pool})
+	if err != nil {
 		t.Errorf("Chain verification failed %v", err)
 	} else {
 		fmt.Println("Chain verification succeeded")
@@ -60,20 +59,20 @@ func TestLeafRootCertVerificationSuccess(t *testing.T) {
 }
 
 func TestLeafIntermediateRootCertVerificationSuccess(t *testing.T) {
-	header_mock, err:= os.ReadFile("./testdata/x5c-test.json")
+	header_mock, err := os.ReadFile("./testdata/x5c-test.json")
 	if err != nil {
 		t.Fatalf("Failed while reading json: %v", err)
 	}
 	assert.NoError(t, err)
 
-    assert.NotEmpty(t, header_mock) 
+	assert.NotEmpty(t, header_mock)
 	var jwt JWTCertBundle
-	err =json.Unmarshal(header_mock, &jwt)
-	if err !=nil{
+	err = json.Unmarshal(header_mock, &jwt)
+	if err != nil {
 		t.Fatalf("Failed updating jwt bundle")
 	}
 	assert.NotEmpty(t, jwt)
-	assert.NotEmpty(t, jwt.Alg) 
+	assert.NotEmpty(t, jwt.Alg)
 	assert.NotEmpty(t, jwt.Typ)
 	assert.NotEmpty(t, jwt.X5c)
 	defer gock.Off()
@@ -82,25 +81,25 @@ func TestLeafIntermediateRootCertVerificationSuccess(t *testing.T) {
 		Reply(200).
 		File("testdata/test-trust-list-no-sig.xml")
 	tsl, err := etsi119612.FetchTSL("https://ewc-consortium.github.io/ewc-trust-list/EWC-TL")
-    assert.NoError(t,err)
-	policy := *etsi119612.PolicyAll 
+	assert.NoError(t, err)
+	policy := *etsi119612.PolicyAll
 	policy.AddServiceTypeIdentifier("http://uri.etsi.org/TrstSvc/Svctype/CA/QC")
 	pool := tsl.ToCertPool(&policy)
 	fmt.Println("Number of trusted roots:", len(pool.Subjects()))
 	assert.NotNil(t, pool)
-	leafDER, err:= base64.StdEncoding.DecodeString(jwt.X5c[0])
-	assert.NoError(t,err)
+	leafDER, err := base64.StdEncoding.DecodeString(jwt.X5c[0])
+	assert.NoError(t, err)
 	leafCert, err := x509.ParseCertificate(leafDER)
-	assert.NoError(t,err)
+	assert.NoError(t, err)
 	interDER, err := base64.StdEncoding.DecodeString(jwt.X5c[1])
-    assert.NoError(t, err, "Failed to decode intermediate")
-    interCert, err := x509.ParseCertificate(interDER)
+	assert.NoError(t, err, "Failed to decode intermediate")
+	interCert, err := x509.ParseCertificate(interDER)
 	assert.NoError(t, err, "Failed to parse intermediate certificate")
-	intermediatePool :=x509.NewCertPool()
+	intermediatePool := x509.NewCertPool()
 	intermediatePool.AddCert(interCert)
 	_, err = leafCert.Verify(x509.VerifyOptions{
-    Roots:pool, Intermediates:intermediatePool})
-	if err !=nil {
+		Roots: pool, Intermediates: intermediatePool})
+	if err != nil {
 		t.Errorf("Chain verification failed %v", err)
 	} else {
 		fmt.Println("Chain verification succeeded")
@@ -108,14 +107,14 @@ func TestLeafIntermediateRootCertVerificationSuccess(t *testing.T) {
 }
 
 func TestLeafRootCertVerificationSuccessEmptyServiceTypeIdentifier(t *testing.T) {
-	header_mock, err:= os.ReadFile("./testdata/x5c-test-root-leaf.json")
+	header_mock, err := os.ReadFile("./testdata/x5c-test-root-leaf.json")
 	assert.NoError(t, err)
-    assert.NotEmpty(t, header_mock) 
+	assert.NotEmpty(t, header_mock)
 	var jwt JWTCertBundle
-	err =json.Unmarshal(header_mock, &jwt)
+	err = json.Unmarshal(header_mock, &jwt)
 	assert.NoError(t, err, "Failed to unmarshal JWT bundle")
 	assert.NotEmpty(t, jwt)
-	assert.NotEmpty(t, jwt.Alg) 
+	assert.NotEmpty(t, jwt.Alg)
 	assert.NotEmpty(t, jwt.Typ)
 	assert.NotEmpty(t, jwt.X5c)
 	defer gock.Off()
@@ -124,17 +123,17 @@ func TestLeafRootCertVerificationSuccessEmptyServiceTypeIdentifier(t *testing.T)
 		Reply(200).
 		File("testdata/test-trust-list-no-sig.xml")
 	tsl, err := etsi119612.FetchTSL("https://ewc-consortium.github.io/ewc-trust-list/EWC-TL")
-	assert.NoError(t,err)
+	assert.NoError(t, err)
 	pool := tsl.ToCertPool(etsi119612.PolicyAll)
 	fmt.Println("Number of trusted roots:", len(pool.Subjects()))
 	assert.NotNil(t, pool)
-	leafDER, err:= base64.StdEncoding.DecodeString(jwt.X5c[0])
-	assert.NoError(t,err)
+	leafDER, err := base64.StdEncoding.DecodeString(jwt.X5c[0])
+	assert.NoError(t, err)
 	leafCert, err := x509.ParseCertificate(leafDER)
-	assert.NoError(t,err)
+	assert.NoError(t, err)
 	_, err = leafCert.Verify(x509.VerifyOptions{
-    Roots: pool})
-	if err !=nil {
+		Roots: pool})
+	if err != nil {
 		t.Errorf("Chain verification failed %v", err)
 	} else {
 		fmt.Println("Chain verification succeeded")
@@ -142,15 +141,15 @@ func TestLeafRootCertVerificationSuccessEmptyServiceTypeIdentifier(t *testing.T)
 }
 
 func TestLeafRootCertVerificationSuccessTLWithSignature(t *testing.T) {
-	header_mock, err:= os.ReadFile("./testdata/x5c-test-root-leaf.json")
+	header_mock, err := os.ReadFile("./testdata/x5c-test-root-leaf.json")
 	assert.NoError(t, err)
-    
-	assert.NotEmpty(t, header_mock) 
+
+	assert.NotEmpty(t, header_mock)
 	var jwt JWTCertBundle
-	err =json.Unmarshal(header_mock, &jwt)
+	err = json.Unmarshal(header_mock, &jwt)
 	assert.NoError(t, err, "Failed to unmarshal JWT bundle")
 	assert.NotEmpty(t, jwt)
-	assert.NotEmpty(t, jwt.Alg) 
+	assert.NotEmpty(t, jwt.Alg)
 	assert.NotEmpty(t, jwt.Typ)
 	assert.NotEmpty(t, jwt.X5c)
 	defer gock.Off()
@@ -159,29 +158,29 @@ func TestLeafRootCertVerificationSuccessTLWithSignature(t *testing.T) {
 		Reply(200).
 		File("testdata/test-trust-list-with-sig.xml")
 	tsl, err := etsi119612.FetchTSL("https://ewc-consortium.github.io/ewc-trust-list/EWC-TL")
-	assert.NoError(t,err)
+	assert.NoError(t, err)
 	pool := tsl.ToCertPool(etsi119612.PolicyAll)
 	fmt.Println("Number of trusted roots:", len(pool.Subjects()))
 	assert.NotNil(t, pool)
-	leafDER, err:= base64.StdEncoding.DecodeString(jwt.X5c[0])
-	assert.NoError(t,err)
+	leafDER, err := base64.StdEncoding.DecodeString(jwt.X5c[0])
+	assert.NoError(t, err)
 	leafCert, err := x509.ParseCertificate(leafDER)
-	assert.NoError(t,err)
+	assert.NoError(t, err)
 	_, err = leafCert.Verify(x509.VerifyOptions{
-    Roots: pool})
-	if err !=nil {
+		Roots: pool})
+	if err != nil {
 		t.Errorf("Chain verification failed %v", err)
 	} else {
 		fmt.Println("Chain verification succeeded")
 	}
 }
 
-func TestServiceStatusOtherThanGrantedStatusError(t *testing.T){
-	header_mock, err:= os.ReadFile("./testdata/x5c-test-root-leaf.json")
+func TestServiceStatusOtherThanGrantedStatusError(t *testing.T) {
+	header_mock, err := os.ReadFile("./testdata/x5c-test-root-leaf.json")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, header_mock)
 	var jwt JWTCertBundle
-	err =json.Unmarshal(header_mock, &jwt)
+	err = json.Unmarshal(header_mock, &jwt)
 	assert.NoError(t, err, "Failed to unmarshal JWT bundle")
 	assert.NotEmpty(t, jwt)
 	assert.NotEmpty(t, jwt.Alg)
@@ -198,24 +197,25 @@ func TestServiceStatusOtherThanGrantedStatusError(t *testing.T){
 	fmt.Println(policy.ServiceStatus)
 	//keep only other-than-granted in the slice
 	if len(policy.ServiceStatus) > 0 {
-    policy.ServiceStatus = policy.ServiceStatus[1:]}
+		policy.ServiceStatus = policy.ServiceStatus[1:]
+	}
 	fmt.Println("Status to test:", policy.ServiceStatus)
-	pool:= tsl.ToCertPool(&policy)
+	pool := tsl.ToCertPool(&policy)
 	assert.NotNil(t, pool)
-	leafDER, err:= base64.StdEncoding.DecodeString(jwt.X5c[0])
-	assert.NoError(t,err)
+	leafDER, err := base64.StdEncoding.DecodeString(jwt.X5c[0])
+	assert.NoError(t, err)
 	leafCert, err := x509.ParseCertificate(leafDER)
-	assert.NoError(t,err)
+	assert.NoError(t, err)
 	_, err = leafCert.Verify(x509.VerifyOptions{
-    Roots: pool})
-	assert.Error(t,err, "status is not recognized or granted")
+		Roots: pool})
+	assert.Error(t, err, "status is not recognized or granted")
 }
-func TestServiceStatusOneOfInTheListSuccess(t *testing.T){
-	header_mock, err:= os.ReadFile("./testdata/x5c-test-root-leaf.json")
+func TestServiceStatusOneOfInTheListSuccess(t *testing.T) {
+	header_mock, err := os.ReadFile("./testdata/x5c-test-root-leaf.json")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, header_mock)
 	var jwt JWTCertBundle
-	err =json.Unmarshal(header_mock, &jwt)
+	err = json.Unmarshal(header_mock, &jwt)
 	assert.NoError(t, err, "Failed to unmarshal JWT bundle")
 	assert.NotEmpty(t, jwt)
 	assert.NotEmpty(t, jwt.Alg)
@@ -231,15 +231,15 @@ func TestServiceStatusOneOfInTheListSuccess(t *testing.T){
 	policy := *etsi119612.PolicyAll
 	policy.AddServiceStatus("https://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/other-than-granted/")
 	fmt.Println(policy.ServiceStatus)
-	pool:= tsl.ToCertPool(&policy)
+	pool := tsl.ToCertPool(&policy)
 	assert.NotNil(t, pool)
-	leafDER, err:= base64.StdEncoding.DecodeString(jwt.X5c[0])
-	assert.NoError(t,err)
+	leafDER, err := base64.StdEncoding.DecodeString(jwt.X5c[0])
+	assert.NoError(t, err)
 	leafCert, err := x509.ParseCertificate(leafDER)
-	assert.NoError(t,err)
+	assert.NoError(t, err)
 	_, err = leafCert.Verify(x509.VerifyOptions{
-    Roots: pool})
-	if err !=nil {
+		Roots: pool})
+	if err != nil {
 		t.Errorf("Chain verification failed %v", err)
 	} else {
 		fmt.Println("Chain verification succeeded")

--- a/pkg/pipeline/step_generate_lotl.go
+++ b/pkg/pipeline/step_generate_lotl.go
@@ -24,11 +24,11 @@ type LoTLSchemeMetadata struct {
 
 // LoTLPointerMeta represents a pointer entry in the LoTL YAML metadata.
 type LoTLPointerMeta struct {
-	Location             string          `yaml:"location"`
-	SchemeTerritory      string          `yaml:"schemeTerritory,omitempty"`
-	SchemeType           string          `yaml:"schemeType,omitempty"`
-	SchemeOperatorNames  []MultiLangName `yaml:"schemeOperatorNames,omitempty"`
-	MimeType             string          `yaml:"mimeType,omitempty"`
+	Location            string          `yaml:"location"`
+	SchemeTerritory     string          `yaml:"schemeTerritory,omitempty"`
+	SchemeType          string          `yaml:"schemeType,omitempty"`
+	SchemeOperatorNames []MultiLangName `yaml:"schemeOperatorNames,omitempty"`
+	MimeType            string          `yaml:"mimeType,omitempty"`
 }
 
 // GenerateLoTL generates a LoTL (List of Trusted Lists) from a YAML metadata file.

--- a/pkg/resilience/retry.go
+++ b/pkg/resilience/retry.go
@@ -1,0 +1,120 @@
+// Package resilience provides retry and error classification utilities for HTTP
+// fetch operations used by trust list and entity list fetchers.
+package resilience
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Config configures retry behavior for HTTP fetch operations.
+type Config struct {
+	// MaxAttempts is the maximum number of fetch attempts (1 = no retry).
+	// Default: 3 (1 initial + 2 retries).
+	MaxAttempts int
+
+	// RetryBaseDelay is the initial backoff duration; doubled after each attempt.
+	// Default: 500ms.
+	RetryBaseDelay time.Duration
+
+	// MaxBodyBytes limits the response body size. An error is returned if the
+	// response exceeds this limit. Default: 10MB.
+	MaxBodyBytes int64
+}
+
+// DefaultConfig returns a Config with default values.
+func DefaultConfig() Config {
+	return Config{
+		MaxAttempts:    3,
+		RetryBaseDelay: 500 * time.Millisecond,
+		MaxBodyBytes:   10 << 20, // 10 MB
+	}
+}
+
+func (c *Config) withDefaults() Config {
+	out := *c
+	if out.MaxAttempts <= 0 {
+		out.MaxAttempts = 3
+	}
+	if out.RetryBaseDelay <= 0 {
+		out.RetryBaseDelay = 500 * time.Millisecond
+	}
+	if out.MaxBodyBytes <= 0 {
+		out.MaxBodyBytes = 10 << 20
+	}
+	return out
+}
+
+// TransportError wraps a network/transport-level error (DNS, TCP, TLS).
+type TransportError struct {
+	Err error
+}
+
+func (e *TransportError) Error() string { return e.Err.Error() }
+func (e *TransportError) Unwrap() error { return e.Err }
+
+// HTTPStatusError represents a non-200 HTTP response.
+type HTTPStatusError struct {
+	StatusCode int
+	URL        string
+}
+
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("HTTP %d from %s", e.StatusCode, e.URL)
+}
+
+// IsRetryable reports whether err is a transient error worth retrying:
+// transport errors and 5xx HTTP responses.
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if te, ok := err.(*TransportError); ok {
+		_ = te
+		return true
+	}
+	if se, ok := err.(*HTTPStatusError); ok {
+		return se.StatusCode >= http.StatusInternalServerError
+	}
+	return false
+}
+
+// DoWithRetry executes fn with retry and exponential backoff.
+//
+// fn is called up to config.MaxAttempts times. If fn returns an error that
+// IsRetryable classifies as transient (transport errors, 5xx), it is retried
+// after exponential backoff. Non-retryable errors (4xx, parse errors) fail
+// immediately.
+//
+// The context is checked between retries; if cancelled, the last error is
+// returned immediately.
+func DoWithRetry(ctx context.Context, cfg Config, fn func() error) error {
+	cfg = cfg.withDefaults()
+	var lastErr error
+	backoff := cfg.RetryBaseDelay
+
+	for attempt := 0; attempt < cfg.MaxAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+			backoff *= 2
+		}
+
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+
+		if !IsRetryable(err) {
+			return err
+		}
+	}
+
+	return fmt.Errorf("failed after %d attempts: %w", cfg.MaxAttempts, lastErr)
+}

--- a/pkg/resilience/retry.go
+++ b/pkg/resilience/retry.go
@@ -33,8 +33,9 @@ func DefaultConfig() Config {
 	}
 }
 
-func (c *Config) withDefaults() Config {
-	out := *c
+// WithDefaults returns a copy of the config with zero fields set to defaults.
+func (c Config) WithDefaults() Config {
+	out := c
 	if out.MaxAttempts <= 0 {
 		out.MaxAttempts = 3
 	}
@@ -88,10 +89,10 @@ func IsRetryable(err error) bool {
 // after exponential backoff. Non-retryable errors (4xx, parse errors) fail
 // immediately.
 //
-// The context is checked between retries; if cancelled, the last error is
+// The context is checked between retries; if cancelled, the context error is
 // returned immediately.
 func DoWithRetry(ctx context.Context, cfg Config, fn func() error) error {
-	cfg = cfg.withDefaults()
+	cfg = cfg.WithDefaults()
 	var lastErr error
 	backoff := cfg.RetryBaseDelay
 

--- a/pkg/resilience/retry_test.go
+++ b/pkg/resilience/retry_test.go
@@ -127,7 +127,7 @@ func TestIsRetryable(t *testing.T) {
 
 func TestConfig_Defaults(t *testing.T) {
 	cfg := Config{}
-	c := cfg.withDefaults()
+	c := cfg.WithDefaults()
 	if c.MaxAttempts != 3 {
 		t.Errorf("expected MaxAttempts=3, got %d", c.MaxAttempts)
 	}

--- a/pkg/resilience/retry_test.go
+++ b/pkg/resilience/retry_test.go
@@ -1,0 +1,140 @@
+package resilience
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestDoWithRetry_Success(t *testing.T) {
+	calls := 0
+	err := DoWithRetry(context.Background(), Config{MaxAttempts: 3, RetryBaseDelay: time.Millisecond}, func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestDoWithRetry_TransientThenSuccess(t *testing.T) {
+	calls := 0
+	err := DoWithRetry(context.Background(), Config{MaxAttempts: 3, RetryBaseDelay: time.Millisecond}, func() error {
+		calls++
+		if calls < 3 {
+			return &TransportError{Err: fmt.Errorf("connection refused")}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected success after retries, got: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestDoWithRetry_5xxRetry(t *testing.T) {
+	calls := 0
+	err := DoWithRetry(context.Background(), Config{MaxAttempts: 3, RetryBaseDelay: time.Millisecond}, func() error {
+		calls++
+		if calls < 3 {
+			return &HTTPStatusError{StatusCode: http.StatusServiceUnavailable, URL: "https://example.com"}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected success after 5xx retries, got: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestDoWithRetry_4xxNoRetry(t *testing.T) {
+	calls := 0
+	err := DoWithRetry(context.Background(), Config{MaxAttempts: 3, RetryBaseDelay: time.Millisecond}, func() error {
+		calls++
+		return &HTTPStatusError{StatusCode: http.StatusNotFound, URL: "https://example.com"}
+	})
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (no retry on 404), got %d", calls)
+	}
+}
+
+func TestDoWithRetry_AllAttemptsExhausted(t *testing.T) {
+	calls := 0
+	err := DoWithRetry(context.Background(), Config{MaxAttempts: 2, RetryBaseDelay: time.Millisecond}, func() error {
+		calls++
+		return &TransportError{Err: fmt.Errorf("timeout")}
+	})
+	if err == nil {
+		t.Fatal("expected error when all attempts exhausted")
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls, got %d", calls)
+	}
+}
+
+func TestDoWithRetry_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	calls := 0
+	err := DoWithRetry(ctx, Config{MaxAttempts: 10, RetryBaseDelay: 50 * time.Millisecond}, func() error {
+		calls++
+		return &TransportError{Err: fmt.Errorf("timeout")}
+	})
+	if err == nil {
+		t.Fatal("expected error on context cancellation")
+	}
+	// Should have been cut short by context
+	if calls >= 10 {
+		t.Errorf("expected fewer than 10 calls due to context cancellation, got %d", calls)
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"nil", nil, false},
+		{"transport", &TransportError{Err: fmt.Errorf("dns")}, true},
+		{"500", &HTTPStatusError{StatusCode: 500, URL: "x"}, true},
+		{"503", &HTTPStatusError{StatusCode: 503, URL: "x"}, true},
+		{"404", &HTTPStatusError{StatusCode: 404, URL: "x"}, false},
+		{"400", &HTTPStatusError{StatusCode: 400, URL: "x"}, false},
+		{"generic", fmt.Errorf("other"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsRetryable(tt.err); got != tt.expected {
+				t.Errorf("IsRetryable() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConfig_Defaults(t *testing.T) {
+	cfg := Config{}
+	c := cfg.withDefaults()
+	if c.MaxAttempts != 3 {
+		t.Errorf("expected MaxAttempts=3, got %d", c.MaxAttempts)
+	}
+	if c.RetryBaseDelay != 500*time.Millisecond {
+		t.Errorf("expected RetryBaseDelay=500ms, got %v", c.RetryBaseDelay)
+	}
+	if c.MaxBodyBytes != 10<<20 {
+		t.Errorf("expected MaxBodyBytes=10MB, got %d", c.MaxBodyBytes)
+	}
+}


### PR DESCRIPTION
## Summary

Adds retry with exponential backoff, body size limits, and proper context propagation to all HTTP fetch operations in the g119612 library.

## Motivation

The ETSI TSL and LoTE/LoTL registries in go-trust delegate their HTTP fetching entirely to g119612. A single transient failure (DNS blip, 503, network timeout) during fetch causes the entire trust list load to fail. This is particularly impactful during initial load — the registry never starts.

This mirrors the resilience patterns added to go-trust's own registries in [go-trust#52](https://github.com/sirosfoundation/go-trust/pull/52), but applied at the library level so all g119612 consumers benefit automatically.

## Changes

### New: `pkg/resilience` — retry and error classification

- `DoWithRetry(ctx, config, fn)` — executes fn with retry and exponential backoff
- `TransportError` / `HTTPStatusError` — error types for classification
- `IsRetryable` — transport errors + 5xx = retryable; 4xx + parse errors = fail immediately
- Configurable: `MaxAttempts` (default 3), `RetryBaseDelay` (default 500ms), `MaxBodyBytes` (default 10MB)
- 8 tests covering all retry/no-retry/cancellation scenarios

### `etsi119612` (TSL) — retry + body limit

- `FetchTSLWithOptions` now wraps HTTP fetch in `DoWithRetry`
- New `TSLFetchOptions` fields: `MaxAttempts`, `RetryBaseDelay`, `MaxBodyBytes`
- **Body size limit added** — previously used unbounded `io.ReadAll(resp.Body)`, now limited to 10MB with explicit overflow error
- Referenced TSL fetches (`dereferencePointersTSLsRecursive`) inherit retry from `FetchTSLWithOptions`

### `etsi119602` (LoTE/LoTL) — retry + context + body limit

- `fetchRawWithContentType` now wraps HTTP fetch in `DoWithRetry`
- New `FetchOptions` fields: `MaxAttempts`, `RetryBaseDelay`, `MaxBodyBytes`
- **Context propagation added** — previously used `http.NewRequest` without context; now uses `http.NewRequestWithContext` with a timeout context
- Body size limit now explicitly errors on overflow instead of silently truncating

### Backward compatibility

All new fields are optional with zero-value defaults that map to sensible values (3 attempts, 500ms delay, 10MB limit). Existing callers passing `nil` or zero-value options get the same behavior as before, plus retry.