### PR TITLE
fix: ECDSA P1363 signatures, NextUpdate validity, territory and LoTL pointers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,4 +35,4 @@ require (
 
 replace github.com/moov-io/signedxml v1.2.3 => github.com/sirosfoundation/signedxml v1.4.0-siros1
 
-replace github.com/russellhaering/goxmldsig v1.5.0 => github.com/sirosfoundation/goxmldsig v1.6.0-siros1
+replace github.com/russellhaering/goxmldsig v1.5.0 => github.com/sirosfoundation/goxmldsig v1.6.0-siros3

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/sirosfoundation/go-cryptoutil v0.5.0 h1:ByKuNjHSdlvkOzGeElh0QAku36iuy
 github.com/sirosfoundation/go-cryptoutil v0.5.0/go.mod h1:OZi673Xmf5o2LzF/QMceptIpiB2GKYAYBfEa75ocBss=
 github.com/sirosfoundation/go-cryptoutil/brainpool v0.2.0 h1:tLBZFdBAloNDwP2j87MRW0W/ujrj+EbVylrkWAIHON4=
 github.com/sirosfoundation/go-cryptoutil/brainpool v0.2.0/go.mod h1:h5sFbD8z/TLv+MziA97+UOXwDEN3drSYheRM5X9yaBE=
-github.com/sirosfoundation/goxmldsig v1.6.0-siros1 h1:NK3ysuYilub7oeJg7NDIVmIyFpqXL24FgW6D+88ygMs=
-github.com/sirosfoundation/goxmldsig v1.6.0-siros1/go.mod h1:TrnaquDcYxWXfJrOjeMBTX4mLBeYAqaHEyUeWPxZlBM=
+github.com/sirosfoundation/goxmldsig v1.6.0-siros3 h1:U+PDYpybkwWFLKlZ5DyiLZ4wM4SXg2N50WI/6j4iAvQ=
+github.com/sirosfoundation/goxmldsig v1.6.0-siros3/go.mod h1:qaraNkcCFPSa6qK4nv/qHLniVUiAAN492SfQL/p+bJs=
 github.com/sirosfoundation/signedxml v1.4.0-siros1 h1:+d+j6AQxu9CNylGkmPbUAUdEYny6gvXZxFnuvrPViHk=
 github.com/sirosfoundation/signedxml v1.4.0-siros1/go.mod h1:qXhLkLQ7B8fg9YSTqBmWSynY9tkkEx2QsIBjMeJTGcM=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=

--- a/pkg/dsig/xades.go
+++ b/pkg/dsig/xades.go
@@ -7,12 +7,15 @@ package dsig
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
+	"encoding/asn1"
 	"encoding/base64"
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/beevik/etree"
@@ -90,8 +93,15 @@ func SignXMLWithXAdES(xmlData []byte, signer crypto.Signer, cert *x509.Certifica
 		return nil, fmt.Errorf("failed to sign: %w", err)
 	}
 
+	// For ECDSA keys, convert DER-encoded signature to IEEE P1363 format (r||s)
+	// as required by XML-DSig (https://www.w3.org/TR/xmldsig-core1/#sec-ECDSA)
+	sigBytes, err := ensureP1363Signature(rawSignature, cert.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert ECDSA signature to P1363: %w", err)
+	}
+
 	// Build the complete Signature element
-	sig := buildSignatureElement(signedInfo, rawSignature, cert, object, sigID)
+	sig := buildSignatureElement(signedInfo, sigBytes, cert, object, sigID)
 
 	// Append signature to a copy of the root
 	result := root.Copy()
@@ -288,4 +298,56 @@ func canonicalizeAndHash(el *etree.Element) ([]byte, error) {
 	}
 	hash := sha256.Sum256(canonical)
 	return hash[:], nil
+}
+
+// ecdsaDERSignature holds the two integers from a DER-encoded ECDSA signature.
+type ecdsaDERSignature struct {
+	R, S *big.Int
+}
+
+// ensureP1363Signature converts an ECDSA signature from DER/ASN.1 encoding to
+// IEEE P1363 format (r||s, each zero-padded to the curve's byte length).
+// For non-ECDSA keys, returns the raw signature unchanged.
+func ensureP1363Signature(raw []byte, pub crypto.PublicKey) ([]byte, error) {
+	ecPub, ok := pub.(*ecdsa.PublicKey)
+	if !ok {
+		return raw, nil
+	}
+
+	var sig ecdsaDERSignature
+	if _, err := asn1.Unmarshal(raw, &sig); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal DER ECDSA signature: %w", err)
+	}
+
+	byteLen := (ecPub.Curve.Params().BitSize + 7) / 8
+	out := make([]byte, 2*byteLen)
+
+	rBytes := sig.R.Bytes()
+	sBytes := sig.S.Bytes()
+	copy(out[byteLen-len(rBytes):byteLen], rBytes)
+	copy(out[2*byteLen-len(sBytes):], sBytes)
+
+	return out, nil
+}
+
+// curveByteLen returns the byte length of the curve order for an ECDSA public key.
+// Returns 0 for non-ECDSA keys.
+func curveByteLen(pub crypto.PublicKey) int {
+	ecPub, ok := pub.(*ecdsa.PublicKey)
+	if !ok {
+		return 0
+	}
+	return (ecPub.Curve.Params().BitSize + 7) / 8
+}
+
+// p1363ToDER converts an IEEE P1363 ECDSA signature (r||s) to DER/ASN.1 encoding.
+// This is the inverse of ensureP1363Signature.
+func p1363ToDER(p1363 []byte, curve elliptic.Curve) ([]byte, error) {
+	byteLen := (curve.Params().BitSize + 7) / 8
+	if len(p1363) != 2*byteLen {
+		return nil, fmt.Errorf("P1363 signature has wrong length: got %d, want %d", len(p1363), 2*byteLen)
+	}
+	r := new(big.Int).SetBytes(p1363[:byteLen])
+	s := new(big.Int).SetBytes(p1363[byteLen:])
+	return asn1.Marshal(ecdsaDERSignature{R: r, S: s})
 }

--- a/pkg/dsig/xades.go
+++ b/pkg/dsig/xades.go
@@ -315,29 +315,29 @@ func ensureP1363Signature(raw []byte, pub crypto.PublicKey) ([]byte, error) {
 	}
 
 	var sig ecdsaDERSignature
-	if _, err := asn1.Unmarshal(raw, &sig); err != nil {
+	rest, err := asn1.Unmarshal(raw, &sig)
+	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal DER ECDSA signature: %w", err)
+	}
+	if len(rest) != 0 {
+		return nil, fmt.Errorf("trailing data after DER ECDSA signature")
+	}
+	if sig.R == nil || sig.S == nil {
+		return nil, fmt.Errorf("invalid ECDSA signature: missing r or s")
 	}
 
 	byteLen := (ecPub.Curve.Params().BitSize + 7) / 8
-	out := make([]byte, 2*byteLen)
-
 	rBytes := sig.R.Bytes()
 	sBytes := sig.S.Bytes()
+	if len(rBytes) > byteLen || len(sBytes) > byteLen {
+		return nil, fmt.Errorf("invalid ECDSA signature: r/s too large for curve")
+	}
+
+	out := make([]byte, 2*byteLen)
 	copy(out[byteLen-len(rBytes):byteLen], rBytes)
 	copy(out[2*byteLen-len(sBytes):], sBytes)
 
 	return out, nil
-}
-
-// curveByteLen returns the byte length of the curve order for an ECDSA public key.
-// Returns 0 for non-ECDSA keys.
-func curveByteLen(pub crypto.PublicKey) int {
-	ecPub, ok := pub.(*ecdsa.PublicKey)
-	if !ok {
-		return 0
-	}
-	return (ecPub.Curve.Params().BitSize + 7) / 8
 }
 
 // p1363ToDER converts an IEEE P1363 ECDSA signature (r||s) to DER/ASN.1 encoding.

--- a/pkg/dsig/xades_ecdsa_test.go
+++ b/pkg/dsig/xades_ecdsa_test.go
@@ -1,0 +1,139 @@
+package dsig
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func TestEnsureP1363Signature_ECDSA_P256(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	digest := sha256.Sum256([]byte("test data"))
+	derSig, err := ecdsa.SignASN1(rand.Reader, key, digest[:])
+	if err != nil {
+		t.Fatalf("SignASN1: %v", err)
+	}
+
+	p1363, err := ensureP1363Signature(derSig, &key.PublicKey)
+	if err != nil {
+		t.Fatalf("ensureP1363Signature: %v", err)
+	}
+
+	if len(p1363) != 64 {
+		t.Fatalf("P1363 signature length: got %d, want 64", len(p1363))
+	}
+
+	// Verify the P1363 signature by extracting r and s
+	r := new(big.Int).SetBytes(p1363[:32])
+	s := new(big.Int).SetBytes(p1363[32:])
+	if !ecdsa.Verify(&key.PublicKey, digest[:], r, s) {
+		t.Fatal("P1363 signature does not verify")
+	}
+}
+
+func TestEnsureP1363Signature_RSA_Passthrough(t *testing.T) {
+	raw := []byte("not-an-ecdsa-key")
+	// For RSA (nil ECDSA key), should pass through unchanged
+	type fakeRSAKey struct{}
+	result, err := ensureP1363Signature(raw, &fakeRSAKey{})
+	if err != nil {
+		t.Fatalf("ensureP1363Signature with non-ECDSA key: %v", err)
+	}
+	if string(result) != string(raw) {
+		t.Fatal("non-ECDSA signature should pass through unchanged")
+	}
+}
+
+func TestP1363ToDER_Roundtrip(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	digest := sha256.Sum256([]byte("roundtrip test"))
+	derSig, err := ecdsa.SignASN1(rand.Reader, key, digest[:])
+	if err != nil {
+		t.Fatalf("SignASN1: %v", err)
+	}
+
+	// DER → P1363
+	p1363, err := ensureP1363Signature(derSig, &key.PublicKey)
+	if err != nil {
+		t.Fatalf("ensureP1363Signature: %v", err)
+	}
+
+	// P1363 → DER
+	derAgain, err := p1363ToDER(p1363, elliptic.P256())
+	if err != nil {
+		t.Fatalf("p1363ToDER: %v", err)
+	}
+
+	// Verify the round-tripped DER signature
+	var sig ecdsaDERSignature
+	if _, err := asn1.Unmarshal(derAgain, &sig); err != nil {
+		t.Fatalf("Unmarshal round-tripped DER: %v", err)
+	}
+	if !ecdsa.Verify(&key.PublicKey, digest[:], sig.R, sig.S) {
+		t.Fatal("round-tripped DER signature does not verify")
+	}
+}
+
+func generateECDSACert(t *testing.T) (*ecdsa.PrivateKey, *x509.Certificate) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "XAdES ECDSA Test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+
+	return key, cert
+}
+
+func TestSignXMLWithXAdES_ECDSA(t *testing.T) {
+	key, cert := generateECDSACert(t)
+
+	xmlData := []byte(`<Root xmlns="urn:test"><Value>hello</Value></Root>`)
+
+	signed, err := SignXMLWithXAdES(xmlData, key, cert)
+	if err != nil {
+		t.Fatalf("SignXMLWithXAdES: %v", err)
+	}
+
+	if len(signed) == 0 {
+		t.Fatal("signed output is empty")
+	}
+
+	// Verify the signature using our verifier
+	certs := []*x509.Certificate{cert}
+	if _, err := VerifyXMLSignature(signed, certs); err != nil {
+		t.Fatalf("VerifyXMLSignature failed: %v", err)
+	}
+}

--- a/pkg/pipeline/step_generate.go
+++ b/pkg/pipeline/step_generate.go
@@ -52,11 +52,12 @@ type CertificateMetadata struct {
 
 // SchemeMetadata represents the YAML structure for the TSL scheme metadata
 type SchemeMetadata struct {
-	OperatorNames      []MultiLangName `yaml:"operatorNames"`                // At least one name required
-	Type               string          `yaml:"type"`                         // URI identifying the TSL type
-	SequenceNumber     int             `yaml:"sequenceNumber,omitempty"`     // TSL sequence number
-	Id                 string          `yaml:"id,omitempty"`                 // Optional TSL Id attribute
-	DistributionPoints []string        `yaml:"distributionPoints,omitempty"` // Optional distribution point URIs
+	OperatorNames      []MultiLangName `yaml:"operatorNames"`                 // At least one name required
+	Type               string          `yaml:"type"`                          // URI identifying the TSL type
+	SequenceNumber     int             `yaml:"sequenceNumber,omitempty"`      // TSL sequence number
+	Id                 string          `yaml:"id,omitempty"`                  // Optional TSL Id attribute
+	Territory          string          `yaml:"territory,omitempty"`           // Optional scheme territory (e.g., "EU", "SE")
+	DistributionPoints []string        `yaml:"distributionPoints,omitempty"`  // Optional distribution point URIs
 }
 
 // TslId returns the TSL Id attribute value.
@@ -445,6 +446,7 @@ func GenerateTSL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) {
 	schemeInfo := &etsi119612.TSLSchemeInformationType{
 		TSLVersionIdentifier: int(schemeMetadata.SequenceNumber),
 		TslTSLType:           schemeMetadata.Type,
+		TslSchemeTerritory:   schemeMetadata.Territory,
 		ListIssueDateTime:    time.Now().UTC().Format(time.RFC3339),
 		TslNextUpdate: &etsi119612.NextUpdateType{
 			DateTime: time.Now().UTC().Add(180 * 24 * time.Hour).Format(time.RFC3339),

--- a/pkg/pipeline/step_generate_lote.go
+++ b/pkg/pipeline/step_generate_lote.go
@@ -23,6 +23,7 @@ type LoTESchemeMetadata struct {
 	SchemeType     string          `yaml:"schemeType"`
 	Territory      string          `yaml:"territory,omitempty"`
 	SequenceNumber int             `yaml:"sequenceNumber,omitempty"`
+	ValidityDays   int             `yaml:"validityDays,omitempty"`
 }
 
 // LoTEEntityMetadata represents the YAML structure for a trusted entity.
@@ -87,7 +88,12 @@ func GenerateLoTE(pl *Pipeline, ctx *Context, args ...string) (*Context, error) 
 		return nil, fmt.Errorf("scheme.yaml must have a schemeType")
 	}
 
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := time.Now().UTC()
+	validityDays := scheme.ValidityDays
+	if validityDays <= 0 {
+		validityDays = 180
+	}
+	nextUpdate := now.Add(time.Duration(validityDays) * 24 * time.Hour)
 	lote := &etsi119602.ListOfTrustedEntities{
 		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
 			LoTEVersionIdentifier: 1,
@@ -96,8 +102,8 @@ func GenerateLoTE(pl *Pipeline, ctx *Context, args ...string) (*Context, error) 
 			SchemeName:            multiLangToNameSet(scheme.SchemeName),
 			LoTEType:              scheme.SchemeType,
 			LoTESequenceNumber:    scheme.SequenceNumber,
-			ListIssueDateTime:     now,
-			NextUpdate:            now,
+			ListIssueDateTime:     now.Format(time.RFC3339),
+			NextUpdate:            nextUpdate.Format(time.RFC3339),
 		},
 	}
 

--- a/pkg/pipeline/step_generate_lote.go
+++ b/pkg/pipeline/step_generate_lote.go
@@ -93,6 +93,9 @@ func GenerateLoTE(pl *Pipeline, ctx *Context, args ...string) (*Context, error) 
 	if validityDays <= 0 {
 		validityDays = 180
 	}
+	if validityDays > 3650 {
+		return nil, fmt.Errorf("validityDays too large: %d (max 3650)", validityDays)
+	}
 	nextUpdate := now.Add(time.Duration(validityDays) * 24 * time.Hour)
 	lote := &etsi119602.ListOfTrustedEntities{
 		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{

--- a/pkg/pipeline/step_generate_lotl.go
+++ b/pkg/pipeline/step_generate_lotl.go
@@ -1,6 +1,9 @@
 package pipeline
 
 import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"time"
 
@@ -19,6 +22,7 @@ type LoTLSchemeMetadata struct {
 	SchemeType     string            `yaml:"schemeType"`
 	Territory      string            `yaml:"territory,omitempty"`
 	SequenceNumber int               `yaml:"sequenceNumber,omitempty"`
+	ValidityDays   int               `yaml:"validityDays,omitempty"`
 	Pointers       []LoTLPointerMeta `yaml:"pointers,omitempty"`
 }
 
@@ -29,6 +33,7 @@ type LoTLPointerMeta struct {
 	SchemeType          string          `yaml:"schemeType,omitempty"`
 	SchemeOperatorNames []MultiLangName `yaml:"schemeOperatorNames,omitempty"`
 	MimeType            string          `yaml:"mimeType,omitempty"`
+	CertFiles           []string        `yaml:"certFiles,omitempty"`
 }
 
 // GenerateLoTL generates a LoTL (List of Trusted Lists) from a YAML metadata file.
@@ -76,7 +81,12 @@ func GenerateLoTL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) 
 		return nil, fmt.Errorf("lotl.yaml must have a schemeType")
 	}
 
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := time.Now().UTC()
+	validityDays := meta.ValidityDays
+	if validityDays <= 0 {
+		validityDays = 180
+	}
+	nextUpdate := now.Add(time.Duration(validityDays) * 24 * time.Hour)
 	lotl := &etsi119602.ListOfTrustedLists{
 		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
 			LoTEVersionIdentifier: 1,
@@ -85,8 +95,8 @@ func GenerateLoTL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) 
 			SchemeName:            multiLangToNameSet(meta.SchemeName),
 			LoTEType:              meta.SchemeType,
 			LoTESequenceNumber:    meta.SequenceNumber,
-			ListIssueDateTime:     now,
-			NextUpdate:            now,
+			ListIssueDateTime:     now.Format(time.RFC3339),
+			NextUpdate:            nextUpdate.Format(time.RFC3339),
 		},
 	}
 
@@ -96,7 +106,8 @@ func GenerateLoTL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) 
 		if mimeType == "" {
 			mimeType = "application/json"
 		}
-		lotl.ListAndSchemeInformation.PointersToOtherLoTE = append(lotl.ListAndSchemeInformation.PointersToOtherLoTE, etsi119602.OtherLoTEPointer{
+
+		pointer := etsi119602.OtherLoTEPointer{
 			LoTELocation: pm.Location,
 			LoTEQualifiers: []etsi119602.LoTEQualifier{{
 				SchemeTerritory:    pm.SchemeTerritory,
@@ -104,7 +115,32 @@ func GenerateLoTL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) 
 				SchemeOperatorName: multiLangToNameSet(pm.SchemeOperatorNames),
 				MimeType:           mimeType,
 			}},
-		})
+		}
+
+		// Load signer certificates for the pointed-to list
+		for _, certFile := range pm.CertFiles {
+			certPath := certFile
+			if !filepath.IsAbs(certPath) {
+				certPath = filepath.Join(rootDir, certPath)
+			}
+			certData, err := os.ReadFile(certPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read pointer cert file %s: %w", certFile, err)
+			}
+			block, _ := pem.Decode(certData)
+			if block == nil {
+				return nil, fmt.Errorf("failed to decode PEM from pointer cert file %s", certFile)
+			}
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse certificate from %s: %w", certFile, err)
+			}
+			pointer.ServiceDigitalIdentities = append(pointer.ServiceDigitalIdentities, etsi119602.ServiceDigitalIdentity{
+				X509Certificates: []etsi119602.PKIOb{{Val: base64.StdEncoding.EncodeToString(cert.Raw)}},
+			})
+		}
+
+		lotl.ListAndSchemeInformation.PointersToOtherLoTE = append(lotl.ListAndSchemeInformation.PointersToOtherLoTE, pointer)
 	}
 
 	if pl != nil && pl.Logger != nil {

--- a/pkg/pipeline/step_generate_lotl.go
+++ b/pkg/pipeline/step_generate_lotl.go
@@ -1,14 +1,12 @@
 package pipeline
 
 import (
-	"crypto/x509"
 	"encoding/base64"
-	"encoding/pem"
 	"fmt"
-	"time"
-
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/sirosfoundation/g119612/pkg/etsi119602"
 	"github.com/sirosfoundation/g119612/pkg/logging"
@@ -86,6 +84,9 @@ func GenerateLoTL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) 
 	if validityDays <= 0 {
 		validityDays = 180
 	}
+	if validityDays > 3650 {
+		return nil, fmt.Errorf("validityDays too large: %d (max 3650)", validityDays)
+	}
 	nextUpdate := now.Add(time.Duration(validityDays) * 24 * time.Hour)
 	lotl := &etsi119602.ListOfTrustedLists{
 		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
@@ -108,7 +109,8 @@ func GenerateLoTL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) 
 		}
 
 		pointer := etsi119602.OtherLoTEPointer{
-			LoTELocation: pm.Location,
+			LoTELocation:              pm.Location,
+			ServiceDigitalIdentities: []etsi119602.ServiceDigitalIdentity{},
 			LoTEQualifiers: []etsi119602.LoTEQualifier{{
 				SchemeTerritory:    pm.SchemeTerritory,
 				LoTEType:           pm.SchemeType,
@@ -119,24 +121,22 @@ func GenerateLoTL(pl *Pipeline, ctx *Context, args ...string) (*Context, error) 
 
 		// Load signer certificates for the pointed-to list
 		for _, certFile := range pm.CertFiles {
-			certPath := certFile
-			if !filepath.IsAbs(certPath) {
-				certPath = filepath.Join(rootDir, certPath)
+			certPath := filepath.Clean(certFile)
+			if filepath.IsAbs(certPath) {
+				return nil, fmt.Errorf("absolute paths not allowed in certFiles: %s", certFile)
 			}
-			certData, err := os.ReadFile(certPath)
+			certPath = filepath.Join(rootDir, certPath)
+			// Ensure resolved path stays within rootDir
+			rel, err := filepath.Rel(rootDir, certPath)
+			if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				return nil, fmt.Errorf("certFile path escapes root directory: %s", certFile)
+			}
+			derBytes, err := loadCertificateDER(certPath)
 			if err != nil {
-				return nil, fmt.Errorf("failed to read pointer cert file %s: %w", certFile, err)
-			}
-			block, _ := pem.Decode(certData)
-			if block == nil {
-				return nil, fmt.Errorf("failed to decode PEM from pointer cert file %s", certFile)
-			}
-			cert, err := x509.ParseCertificate(block.Bytes)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse certificate from %s: %w", certFile, err)
+				return nil, fmt.Errorf("failed to load pointer cert file %s: %w", certFile, err)
 			}
 			pointer.ServiceDigitalIdentities = append(pointer.ServiceDigitalIdentities, etsi119602.ServiceDigitalIdentity{
-				X509Certificates: []etsi119602.PKIOb{{Val: base64.StdEncoding.EncodeToString(cert.Raw)}},
+				X509Certificates: []etsi119602.PKIOb{{Val: base64.StdEncoding.EncodeToString(derBytes)}},
 			})
 		}
 


### PR DESCRIPTION
## Summary

Fixes multiple issues discovered during trust.siros.org integration testing (see sirosfoundation/go-trust#59).

## Changes

### 1. ECDSA XML-DSig signature encoding (CRITICAL)

`crypto.Signer.Sign()` returns DER/ASN.1 encoded ECDSA signatures, but the [XML-DSig spec](https://www.w3.org/TR/xmldsig-core1/#sec-ECDSA) requires IEEE P1363 format (r‖s concatenation) in `<SignatureValue>`.

- **Before:** ewc-demo.xml: 70-byte DER signature → verification failure
- **After:** 64-byte P1363 signature → correct per spec

Added `ensureP1363Signature()` in `pkg/dsig/xades.go` and comprehensive tests in `xades_ecdsa_test.go` (P1363 conversion, RSA passthrough, DER roundtrip, full XAdES ECDSA sign+verify).

### 2. NextUpdate == ListIssueDateTime (LoTE + LoTL)

`step_generate_lote.go` and `step_generate_lotl.go` both set `NextUpdate` to the same timestamp as `ListIssueDateTime`, making lists appear expired at publication time.

- Added `ValidityDays` field to `LoTESchemeMetadata` and `LoTLSchemeMetadata`
- Defaults to 180 days if not specified
- `NextUpdate = ListIssueDateTime + validityDays`

### 3. Missing SchemeTerritory in TSL generation

Added `Territory` field to `SchemeMetadata` in `step_generate.go` and pass it through to `TslSchemeTerritory`.

### 4. LoTL pointers missing ServiceDigitalIdentities

Added `CertFiles` field to `LoTLPointerMeta` so that `lotl.yaml` can reference PEM certificate files to populate `ServiceDigitalIdentities` on `OtherLoTEPointer` entries.

## Testing

All tests pass (`go test ./...` — 14 packages, 0 failures).

## Dependencies

Requires sirosfoundation/goxmldsig#1 (ECDSA P1363 verification) to be merged first and go.mod updated.

## Merge order

1. sirosfoundation/goxmldsig#1
2. **This PR**
3. sirosfoundation/trust-lists (metadata fixes)