### PR TITLE
fix: harden GitHub Actions permissions and prevent script injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
@@ -36,6 +36,8 @@ jobs:
   publish:
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,12 @@
 on: [push, pull_request]
 name: Test
-permissions: write-all
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-go@v6

--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,10 @@ runs:
     - name: Determine version
       id: version
       shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
       run: |
-        VERSION="${{ inputs.version }}"
+        VERSION="$INPUT_VERSION"
         if [ "$VERSION" = "latest" ]; then
           # Follow the /latest redirect to get the tag name from the URL
           VERSION=$(curl -sfLI -o /dev/null -w '%{url_effective}' \


### PR DESCRIPTION
## SonarCloud Security Fixes

Addresses 3 security vulnerabilities flagged by SonarCloud:

### 1. test.yml — `permissions: write-all` (Low severity)
Replaced workflow-level `write-all` with `contents: read` at workflow level and `contents: write` scoped to the test job (needed for badge push).

### 2. release.yml — workflow-level `contents: write` (Low severity)  
Moved `contents: write` from workflow level to only the `publish` job that actually needs it.

### 3. action.yml — Script injection via `inputs.version` (Blocker)
`${{ inputs.version }}` was interpolated directly in a `run:` block, allowing script injection by anyone triggering the workflow. Fixed by passing the input through an environment variable instead.

**Expected impact**: Security rating E → C or better