### PR TITLE
feat(generate-lote): read distributionPoints from scheme.yaml

### DIFF
--- a/pkg/pipeline/generate_lote_test.go
+++ b/pkg/pipeline/generate_lote_test.go
@@ -262,3 +262,87 @@ informationURI:
 	assert.Equal(t, "http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/granted",
 		lote.TrustedEntitiesList[0].TrustedEntityServices[0].ServiceInformation.ServiceStatus)
 }
+
+// writeMinimalScheme creates a list directory containing only scheme.yaml,
+// which is enough for GenerateLoTE to produce an entity-less LoTE.
+func writeMinimalScheme(t *testing.T, extra string) string {
+	t.Helper()
+	dir := t.TempDir()
+	schemeYAML := `operatorNames:
+  - language: en
+    value: "Test Operator"
+schemeType: "http://example.com/lote"
+territory: SE
+sequenceNumber: 1
+` + extra
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "scheme.yaml"), []byte(schemeYAML), 0644))
+	return dir
+}
+
+func TestGenerateLoTE_DistributionPoints(t *testing.T) {
+	dir := writeMinimalScheme(t, `distributionPoints:
+  - "https://trust.example.com/my-list.xml"
+`)
+
+	ctx := NewContext()
+	ctx, err := GenerateLoTE(nil, ctx, dir)
+	require.NoError(t, err)
+
+	lote := ctx.GetLoTEs()[0]
+	assert.Equal(t,
+		[]string{"https://trust.example.com/my-list.xml"},
+		lote.ListAndSchemeInformation.DistributionPoints)
+}
+
+// Two schemes sharing a territory would both publish as lote-SE.json and
+// silently overwrite one another; a distribution point gives each its own
+// filename. This is the whole reason the field is plumbed through.
+func TestGenerateLoTE_DistributionPointDrivesFilename(t *testing.T) {
+	outDir := t.TempDir()
+	ctx := NewContext()
+
+	for _, name := range []string{"first", "second"} {
+		dir := writeMinimalScheme(t, `distributionPoints:
+  - "https://trust.example.com/`+name+`.xml"
+`)
+		var err error
+		ctx, err = GenerateLoTE(nil, ctx, dir)
+		require.NoError(t, err)
+	}
+
+	_, err := PublishLoTE(nil, ctx, outDir)
+	require.NoError(t, err)
+
+	for _, name := range []string{"first", "second"} {
+		assert.FileExists(t, filepath.Join(outDir, name+".json"))
+	}
+	assert.NoFileExists(t, filepath.Join(outDir, "lote-SE.json"),
+		"territory-derived name should not be used when a distribution point is set")
+}
+
+func TestGenerateLoTE_InvalidDistributionPoint(t *testing.T) {
+	dir := writeMinimalScheme(t, `distributionPoints:
+  - "not-a-url"
+`)
+
+	ctx := NewContext()
+	_, err := GenerateLoTE(nil, ctx, dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid distributionPoint")
+}
+
+// Without a distribution point the territory-derived name must still apply,
+// so existing lists keep their published filenames.
+func TestGenerateLoTE_NoDistributionPointsKeepsTerritoryName(t *testing.T) {
+	dir := writeMinimalScheme(t, "")
+	outDir := t.TempDir()
+
+	ctx := NewContext()
+	ctx, err := GenerateLoTE(nil, ctx, dir)
+	require.NoError(t, err)
+	assert.Empty(t, ctx.GetLoTEs()[0].ListAndSchemeInformation.DistributionPoints)
+
+	_, err = PublishLoTE(nil, ctx, outDir)
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(outDir, "lote-SE.json"))
+}

--- a/pkg/pipeline/step_generate_lote.go
+++ b/pkg/pipeline/step_generate_lote.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sirosfoundation/g119612/pkg/etsi119602"
 	"github.com/sirosfoundation/g119612/pkg/logging"
+	"github.com/sirosfoundation/g119612/pkg/validation"
 	"gopkg.in/yaml.v3"
 )
 
@@ -24,6 +25,13 @@ type LoTESchemeMetadata struct {
 	Territory      string          `yaml:"territory,omitempty"`
 	SequenceNumber int             `yaml:"sequenceNumber,omitempty"`
 	ValidityDays   int             `yaml:"validityDays,omitempty"`
+
+	// DistributionPoints lists the URIs the published list is served from
+	// (ETSI TS 119 602 LoTEDistributionPoints). Beyond appearing in the
+	// document, the first entry determines the output filename in
+	// publish-lote, so schemes that share a territory need one here to
+	// avoid overwriting each other.
+	DistributionPoints []string `yaml:"distributionPoints,omitempty"`
 }
 
 // LoTEEntityMetadata represents the YAML structure for a trusted entity.
@@ -87,6 +95,11 @@ func GenerateLoTE(pl *Pipeline, ctx *Context, args ...string) (*Context, error) 
 	if scheme.SchemeType == "" {
 		return nil, fmt.Errorf("scheme.yaml must have a schemeType")
 	}
+	for _, dp := range scheme.DistributionPoints {
+		if err := validation.ValidateURL(dp, validation.TSLURLOptions()); err != nil {
+			return nil, fmt.Errorf("invalid distributionPoint %q in scheme.yaml: %w", dp, err)
+		}
+	}
 
 	now := time.Now().UTC()
 	validityDays := scheme.ValidityDays
@@ -107,6 +120,7 @@ func GenerateLoTE(pl *Pipeline, ctx *Context, args ...string) (*Context, error) 
 			LoTESequenceNumber:    scheme.SequenceNumber,
 			ListIssueDateTime:     now.Format(time.RFC3339),
 			NextUpdate:            nextUpdate.Format(time.RFC3339),
+			DistributionPoints:    scheme.DistributionPoints,
 		},
 	}
 


### PR DESCRIPTION
## Problem

`publish-lote` already prefers a distribution point URI when naming its output and only falls back to the territory (`loteFilename`, `step_publish_lote.go:261`):

```go
if lote.ListAndSchemeInformation.SchemeTerritory != "" {
    return fmt.Sprintf("lote-%s.json", lote.ListAndSchemeInformation.SchemeTerritory)
}
```

But `generate-lote` had no way to set one — `LoTESchemeMetadata` didn't parse the field — so natively generated LoTEs always landed on `lote-<territory>.json`.

Every list sharing a territory therefore publishes to the same filename and **silently overwrites** the others. [`sirosfoundation/trust-lists`](https://github.com/sirosfoundation/trust-lists) has three such lists — `digital-credentials.dev`, `multipaz.org` and `siros-multipaz-verifier` are all territory `SE` — so only whichever runs last survives, and none can be referenced by name.

This is already live: `digital-credentials.dev` merged 2026-07-22 and is on trust.siros.org today as `lote-SE.json`, not under its own name.

The one list that does get a stable name, `ewc-demo`, gets it precisely because it arrives via `convert-to-lote`, which carries distribution points over from the source TSL.

## Fix

Parse `distributionPoints` and populate `LoTEDistributionPoints`. The field is part of ETSI TS 119 602 `ListAndSchemeInformation` and belongs in these documents regardless of the filename effect — a published list should say where it is served from. URIs are validated on the same terms as other pipeline URLs.

```yaml
distributionPoints:
  - "https://trust.siros.org/multipaz.org.xml"
```

## Compatibility

Unchanged for schemes that omit the field — they keep the territory-derived filename. Covered by `TestGenerateLoTE_NoDistributionPointsKeepsTerritoryName`.

## Testing

Four new tests in `pkg/pipeline`; confirmed the three positive ones fail without the source change.

Full publish loop over all six real trust-lists directories, signed against a local SoftHSM token, with `distributionPoints` added to the three SE lists:

```
digital-credentials.dev.json[.jws]  .xml
ewc-demo.json[.jws]                 .xml
multipaz.org.json[.jws]             .xml
siros-multipaz-verifier.json[.jws]  .xml
lote-demo.json[.jws]                .xml     <- siros-demo, no distributionPoints, name unchanged
list_of_trusted_lists-demo.json[.jws]
```

No `lote-SE.json` collision, and the certificates are embedded verbatim.

Note this run also needs #58 — without it the two multipaz lists fail to parse at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)