### PR TITLE
test(etsi119612): pin x5c chain verification to a fixed time

### DIFF
--- a/pkg/etsi119612/x5c_validation_test.go
+++ b/pkg/etsi119612/x5c_validation_test.go
@@ -10,7 +10,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+	"time"
 )
+
+// x5cTestTime pins chain verification to a point inside the fixtures'
+// validity window. The Sunet test leaves in testdata are one-year certs
+// issued in June 2025, so verifying against the wall clock made these tests
+// start failing on 2026-06-26 regardless of the code under test. What is
+// being tested here is trust-list-driven path building, not expiry.
+var x5cTestTime = time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
 
 type JWTCertBundle struct {
 	Alg string   `json:"alg"`
@@ -50,7 +58,7 @@ func TestLeafRootCertVerificationSuccess(t *testing.T) {
 	leafCert, err := x509.ParseCertificate(leafDER)
 	assert.NoError(t, err)
 	_, err = leafCert.Verify(x509.VerifyOptions{
-		Roots: pool})
+		Roots: pool, CurrentTime: x5cTestTime})
 	if err != nil {
 		t.Errorf("Chain verification failed %v", err)
 	} else {
@@ -98,7 +106,7 @@ func TestLeafIntermediateRootCertVerificationSuccess(t *testing.T) {
 	intermediatePool := x509.NewCertPool()
 	intermediatePool.AddCert(interCert)
 	_, err = leafCert.Verify(x509.VerifyOptions{
-		Roots: pool, Intermediates: intermediatePool})
+		Roots: pool, Intermediates: intermediatePool, CurrentTime: x5cTestTime})
 	if err != nil {
 		t.Errorf("Chain verification failed %v", err)
 	} else {
@@ -132,7 +140,7 @@ func TestLeafRootCertVerificationSuccessEmptyServiceTypeIdentifier(t *testing.T)
 	leafCert, err := x509.ParseCertificate(leafDER)
 	assert.NoError(t, err)
 	_, err = leafCert.Verify(x509.VerifyOptions{
-		Roots: pool})
+		Roots: pool, CurrentTime: x5cTestTime})
 	if err != nil {
 		t.Errorf("Chain verification failed %v", err)
 	} else {
@@ -167,7 +175,7 @@ func TestLeafRootCertVerificationSuccessTLWithSignature(t *testing.T) {
 	leafCert, err := x509.ParseCertificate(leafDER)
 	assert.NoError(t, err)
 	_, err = leafCert.Verify(x509.VerifyOptions{
-		Roots: pool})
+		Roots: pool, CurrentTime: x5cTestTime})
 	if err != nil {
 		t.Errorf("Chain verification failed %v", err)
 	} else {
@@ -207,7 +215,7 @@ func TestServiceStatusOtherThanGrantedStatusError(t *testing.T) {
 	leafCert, err := x509.ParseCertificate(leafDER)
 	assert.NoError(t, err)
 	_, err = leafCert.Verify(x509.VerifyOptions{
-		Roots: pool})
+		Roots: pool, CurrentTime: x5cTestTime})
 	assert.Error(t, err, "status is not recognized or granted")
 }
 func TestServiceStatusOneOfInTheListSuccess(t *testing.T) {
@@ -238,7 +246,7 @@ func TestServiceStatusOneOfInTheListSuccess(t *testing.T) {
 	leafCert, err := x509.ParseCertificate(leafDER)
 	assert.NoError(t, err)
 	_, err = leafCert.Verify(x509.VerifyOptions{
-		Roots: pool})
+		Roots: pool, CurrentTime: x5cTestTime})
 	if err != nil {
 		t.Errorf("Chain verification failed %v", err)
 	} else {


### PR DESCRIPTION
## Problem

`main` has been red since 2026-06-26. The five x5c validation tests verify certificate chains against the wall clock, and the Sunet test leaves in `testdata` are one-year certificates issued in June 2025:

```
x509: certificate has expired or is not yet valid:
  current time 2026-08-22T11:41:37Z is after 2026-06-27T10:48:54Z
```

```
testdata/x5c-test.json           leaf  notAfter=Jun 26 08:57:23 2026 GMT
testdata/x5c-test-root-leaf.json leaf  notAfter=Jun 27 10:48:54 2026 GMT
```

Failing: `TestLeafRootCertVerificationSuccess`, `TestLeafIntermediateRootCertVerificationSuccess`, `TestLeafRootCertVerificationSuccessEmptyServiceTypeIdentifier`, `TestLeafRootCertVerificationSuccessTLWithSignature`, `TestServiceStatusOneOfInTheListSuccess`.

## Fix

What these tests actually cover is trust-list-driven path building — that `ToCertPool` yields roots the leaf chains to under a given policy. Expiry is incidental, and checking it against `time.Now()` only guarantees the suite rots.

Pin `CurrentTime` to 2025-09-01, inside the validity window of every fixture.

## Side benefit

This strengthens `TestServiceStatusOneOfInTheListSuccess`. It asserts verification *fails* for a non-granted service status — which, once the fixtures expired, would have passed for the wrong reason. It still passes with time pinned, so the status policy is genuinely what rejects the chain.

## Testing

Full suite green, 0 failures — first time since June.

## Why now

This blocks #58 and #59, both of which are otherwise green. Worth merging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)