### PR TITLE
feat(tsl-tool): issue self-signed certificates for existing PKCS#11 keys

### DIFF
--- a/cmd/tsl-tool/main.go
+++ b/cmd/tsl-tool/main.go
@@ -59,12 +59,15 @@ package main
 
 import (
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
 	"flag"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/sirosfoundation/g119612/pkg/dsig"
 	"github.com/sirosfoundation/g119612/pkg/etsi119612"
 	"github.com/sirosfoundation/g119612/pkg/logging"
 	"github.com/sirosfoundation/g119612/pkg/pipeline"
@@ -151,12 +154,70 @@ See: https://github.com/sirosfoundation/g119612
 `, prog, prog, prog)
 }
 
+// runSelfSignCert issues a self-signed certificate for a key pair that already
+// exists in a PKCS#11 token, so the certificate and the signing key cannot
+// disagree. See dsig.SelfSignCertificate for why this is not done with openssl.
+func runSelfSignCert(pkcs11URI, keyLabel, keyID, certLabel, subject string, days int, outputFile string) error {
+	if pkcs11URI == "" {
+		return fmt.Errorf("-pkcs11-uri is required with -selfsign-cert")
+	}
+	if subject == "" {
+		return fmt.Errorf("-subject is required with -selfsign-cert")
+	}
+	if days <= 0 {
+		return fmt.Errorf("-days must be positive, got %d", days)
+	}
+
+	config := dsig.ExtractPKCS11Config(pkcs11URI)
+	if config == nil {
+		return fmt.Errorf("invalid PKCS#11 URI")
+	}
+
+	cert, pemBytes, err := dsig.SelfSignCertificate(config, dsig.SelfSignedCertOptions{
+		KeyLabel:  keyLabel,
+		KeyID:     keyID,
+		CertLabel: certLabel,
+		Subject:   pkix.Name{CommonName: subject},
+		Validity:  time.Duration(days) * 24 * time.Hour,
+	})
+	if err != nil {
+		return err
+	}
+
+	if outputFile != "" {
+		if err := os.WriteFile(outputFile, pemBytes, 0644); err != nil {
+			return fmt.Errorf("failed to write certificate to %s: %w", outputFile, err)
+		}
+		fmt.Fprintf(os.Stderr, "Wrote certificate to %s\n", outputFile)
+	} else {
+		if _, err := os.Stdout.Write(pemBytes); err != nil {
+			return fmt.Errorf("failed to write certificate: %w", err)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Subject:   %s\n", cert.Subject)
+	fmt.Fprintf(os.Stderr, "Serial:    %s\n", cert.SerialNumber)
+	fmt.Fprintf(os.Stderr, "Not after: %s\n", cert.NotAfter.Format(time.RFC3339))
+	if certLabel != "" {
+		fmt.Fprintf(os.Stderr, "Stored in token under label %q\n", certLabel)
+	}
+	return nil
+}
+
 func main() {
 	showHelp := flag.Bool("help", false, "Show help message")
 	showVersion := flag.Bool("version", false, "Show version information")
 	logLevel := flag.String("log-level", "info", "Logging level: debug, info, warn, error")
 	logFormat := flag.String("log-format", "text", "Logging format: text or json")
 	outputFile := flag.String("output", "", "Write certificate pool PEM to file")
+
+	selfSignCert := flag.Bool("selfsign-cert", false, "Issue a self-signed certificate for an existing PKCS#11 key instead of running a pipeline")
+	pkcs11URI := flag.String("pkcs11-uri", "", "PKCS#11 URI (with -selfsign-cert)")
+	keyLabel := flag.String("key-label", "signing-key", "PKCS#11 key label (with -selfsign-cert)")
+	keyID := flag.String("key-id", "01", "PKCS#11 key ID in hex (with -selfsign-cert)")
+	certLabel := flag.String("cert-label", "", "Store the certificate in the token under this label (with -selfsign-cert)")
+	subject := flag.String("subject", "", "Certificate common name (with -selfsign-cert)")
+	days := flag.Int("days", 1095, "Certificate validity in days (with -selfsign-cert)")
 
 	flag.Usage = usage
 	flag.Parse()
@@ -168,6 +229,14 @@ func main() {
 
 	if *showVersion {
 		fmt.Printf("tsl-tool version %s\n", Version)
+		os.Exit(0)
+	}
+
+	if *selfSignCert {
+		if err := runSelfSignCert(*pkcs11URI, *keyLabel, *keyID, *certLabel, *subject, *days, *outputFile); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
 		os.Exit(0)
 	}
 

--- a/pkg/dsig/pkcs11_selfsign.go
+++ b/pkg/dsig/pkcs11_selfsign.go
@@ -1,0 +1,126 @@
+package dsig
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ThalesGroup/crypto11"
+)
+
+// SelfSignedCertOptions configures SelfSignCertificate.
+type SelfSignedCertOptions struct {
+	// KeyLabel and KeyID identify the existing key pair in the token. The
+	// certificate is issued for whatever public key that pair holds.
+	KeyLabel string
+	KeyID    string
+
+	// Subject is the distinguished name for both subject and issuer.
+	Subject pkix.Name
+
+	// Validity is how long the certificate is valid from now.
+	Validity time.Duration
+
+	// CertLabel, when non-empty, is the label to store the certificate under
+	// in the token. Any existing certificate with that label and the same ID
+	// is removed first, so the token never ends up with a stale one alongside.
+	CertLabel string
+}
+
+// SelfSignCertificate issues a self-signed CA certificate for a key pair that
+// already exists in a PKCS#11 token, using that token to produce the signature.
+// The private key never leaves the token.
+//
+// This exists because the obvious shell recipe is wrong in a way that is hard
+// to notice. Generating a key in a token with pkcs11-tool and then minting a
+// certificate with "openssl req -x509 -newkey ..." produces a certificate over
+// a brand new, unrelated key pair; loading it into the token leaves the
+// certificate and the signing key referring to different keys. Signatures then
+// verify against nothing, and the failure only shows up in a relying party,
+// never at signing time.
+//
+// Returns the certificate and its PEM encoding.
+func SelfSignCertificate(config *crypto11.Config, opts SelfSignedCertOptions) (*x509.Certificate, []byte, error) {
+	if config == nil {
+		return nil, nil, fmt.Errorf("nil PKCS#11 config")
+	}
+	if opts.KeyLabel == "" {
+		return nil, nil, fmt.Errorf("key label is required")
+	}
+	if opts.Validity <= 0 {
+		return nil, nil, fmt.Errorf("validity must be positive, got %s", opts.Validity)
+	}
+
+	idBytes, err := hexToBytes(opts.KeyID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to convert key ID to bytes: %w", err)
+	}
+
+	ctx, err := crypto11.Configure(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to configure PKCS#11 context: %w", err)
+	}
+
+	signer, err := ctx.FindKeyPair(idBytes, []byte(opts.KeyLabel))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to find key pair with label %q and ID %q: %w",
+			opts.KeyLabel, opts.KeyID, err)
+	}
+	if signer == nil {
+		return nil, nil, fmt.Errorf("no key pair with label %q and ID %q in token",
+			opts.KeyLabel, opts.KeyID)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 127))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	now := time.Now().UTC()
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               opts.Subject,
+		Issuer:                opts.Subject,
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(opts.Validity),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+
+	// The public key comes from the token's key pair, and the token signs.
+	// That is what ties the certificate to the key that will actually sign.
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, signer.Public(), signer)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse generated certificate: %w", err)
+	}
+
+	// Refuse to hand back a certificate that does not match its own key. This
+	// is the invariant the whole function exists to guarantee.
+	if err := cert.CheckSignatureFrom(cert); err != nil {
+		return nil, nil, fmt.Errorf("generated certificate does not verify against its own key: %w", err)
+	}
+
+	if opts.CertLabel != "" {
+		// Drop any prior certificate under this label/ID so a stale one cannot
+		// be picked up instead. Absence is fine.
+		if err := ctx.DeleteCertificate(idBytes, []byte(opts.CertLabel), nil); err != nil {
+			return nil, nil, fmt.Errorf("failed to remove existing certificate %q: %w", opts.CertLabel, err)
+		}
+		if err := ctx.ImportCertificateWithLabel(idBytes, []byte(opts.CertLabel), cert); err != nil {
+			return nil, nil, fmt.Errorf("failed to import certificate %q into token: %w", opts.CertLabel, err)
+		}
+	}
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return cert, pemBytes, nil
+}

--- a/test/selfsign/selfsign_softhsm_test.go
+++ b/test/selfsign/selfsign_softhsm_test.go
@@ -1,0 +1,161 @@
+//go:build softhsm
+
+// Package selfsign exercises dsig.SelfSignCertificate against a real SoftHSM
+// token.
+//
+// It lives in its own directory, and so its own test binary, on purpose. The
+// PKCS#11 module can only be initialized once per process, and pkg/dsig's
+// other tests initialize it against a token directory they then delete, which
+// leaves any later crypto11.Configure in that binary failing with
+// CKR_GENERAL_ERROR. pkg/jws and pkg/pipeline get away with their SoftHSM
+// tests for the same reason: separate package, separate process.
+package selfsign
+
+import (
+	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"testing"
+	"time"
+
+	"github.com/ThalesGroup/crypto11"
+	"github.com/sirosfoundation/g119612/pkg/dsig"
+	"github.com/sirosfoundation/g119612/pkg/dsig/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	selfSignKeyLabel  = "test-key"
+	selfSignCertLabel = "test-cert"
+	selfSignKeyID     = "01"
+)
+
+var selfSignKeyIDBytes = []byte{0x01}
+
+// TestSelfSignCertificate covers issuing a certificate for a key that already
+// lives in a PKCS#11 token.
+//
+// The subtests share one token and one crypto11 context deliberately: the
+// PKCS#11 module cannot be initialized more than once per process, so a helper
+// that configured a fresh context per test would fail with CKR_GENERAL_ERROR.
+// They therefore run in order, and the first one depends on the token still
+// being in its initial state.
+func TestSelfSignCertificate(t *testing.T) {
+	helper := test.SkipIfSoftHSMUnavailable(t)
+	require.NoError(t, helper.Setup())
+	t.Cleanup(func() { _ = helper.Cleanup() })
+
+	if err := helper.GenerateAndImportTestCert(selfSignKeyLabel, selfSignCertLabel, selfSignKeyID); err != nil {
+		t.Skipf("could not set up SoftHSM token: %v", err)
+	}
+
+	config := dsig.ExtractPKCS11Config(helper.GetPKCS11URI())
+	require.NotNil(t, config)
+
+	ctx, err := crypto11.Configure(config)
+	require.NoError(t, err)
+
+	keyPair, err := ctx.FindKeyPair(selfSignKeyIDBytes, []byte(selfSignKeyLabel))
+	require.NoError(t, err)
+	require.NotNil(t, keyPair)
+
+	type equaler interface{ Equal(x crypto.PublicKey) bool }
+	tokenKey, ok := keyPair.Public().(equaler)
+	require.True(t, ok, "token public key must support Equal")
+
+	tokenCert := func(t *testing.T) *x509.Certificate {
+		t.Helper()
+		c, err := ctx.FindCertificate(selfSignKeyIDBytes, []byte(selfSignCertLabel), nil)
+		require.NoError(t, err)
+		require.NotNil(t, c)
+		return c
+	}
+
+	// This is the regression this whole file exists for. GenerateAndImportTestCert
+	// sets the token up the way the documented shell recipe does: generate a key
+	// pair in the token, then mint a certificate over a separate, throwaway key
+	// and load that. Certificate and signing key then describe different keys,
+	// and every signature produced is unverifiable by anyone holding the
+	// certificate — with no error at signing time.
+	t.Run("fixture starts out mismatched", func(t *testing.T) {
+		assert.False(t, tokenKey.Equal(tokenCert(t).PublicKey),
+			"expected the fixture's certificate to disagree with the token key")
+	})
+
+	t.Run("without cert label the token is left alone", func(t *testing.T) {
+		before := tokenCert(t).Raw
+
+		cert, _, err := dsig.SelfSignCertificate(config, dsig.SelfSignedCertOptions{
+			KeyLabel: selfSignKeyLabel,
+			KeyID:    selfSignKeyID,
+			Subject:  pkix.Name{CommonName: "Self Sign Test"},
+			Validity: 24 * time.Hour,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, before, tokenCert(t).Raw, "token certificate must be untouched")
+		assert.NotEqual(t, cert.Raw, before)
+		// Even when not stored, the certificate must describe the token key.
+		assert.True(t, tokenKey.Equal(cert.PublicKey))
+	})
+
+	t.Run("reissued certificate matches the token key", func(t *testing.T) {
+		cert, pemBytes, err := dsig.SelfSignCertificate(config, dsig.SelfSignedCertOptions{
+			KeyLabel:  selfSignKeyLabel,
+			KeyID:     selfSignKeyID,
+			CertLabel: selfSignCertLabel,
+			Subject:   pkix.Name{CommonName: "Self Sign Test"},
+			Validity:  24 * time.Hour,
+		})
+		require.NoError(t, err)
+		assert.Contains(t, string(pemBytes), "BEGIN CERTIFICATE")
+
+		assert.True(t, tokenKey.Equal(cert.PublicKey),
+			"certificate public key must match the token's signing key")
+		assert.NoError(t, cert.CheckSignatureFrom(cert), "certificate must be self-consistent")
+		assert.Equal(t, "Self Sign Test", cert.Subject.CommonName)
+		assert.True(t, cert.IsCA)
+		assert.Equal(t,
+			x509.KeyUsageDigitalSignature|x509.KeyUsageCertSign|x509.KeyUsageCRLSign,
+			cert.KeyUsage)
+
+		// The token now hands out that certificate, not the stale one, and there
+		// is exactly one certificate under the label.
+		stored := tokenCert(t)
+		assert.Equal(t, cert.Raw, stored.Raw, "token must return the reissued certificate")
+		assert.True(t, tokenKey.Equal(stored.PublicKey))
+	})
+
+	t.Run("missing key is an error", func(t *testing.T) {
+		_, _, err := dsig.SelfSignCertificate(config, dsig.SelfSignedCertOptions{
+			KeyLabel: "no-such-key",
+			KeyID:    selfSignKeyID,
+			Subject:  pkix.Name{CommonName: "Self Sign Test"},
+			Validity: 24 * time.Hour,
+		})
+		require.Error(t, err)
+	})
+}
+
+// Input validation happens before the token is touched, so this needs no HSM.
+func TestSelfSignCertificateValidatesInput(t *testing.T) {
+	t.Run("nil config", func(t *testing.T) {
+		_, _, err := dsig.SelfSignCertificate(nil, dsig.SelfSignedCertOptions{
+			KeyLabel: "k", KeyID: "01", Validity: time.Hour,
+		})
+		require.Error(t, err)
+	})
+
+	cases := map[string]dsig.SelfSignedCertOptions{
+		"no key label":      {KeyID: "01", Validity: time.Hour},
+		"zero validity":     {KeyLabel: "k", KeyID: "01"},
+		"negative validity": {KeyLabel: "k", KeyID: "01", Validity: -time.Hour},
+	}
+	for name, opts := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := dsig.SelfSignCertificate(&crypto11.Config{Path: "/nonexistent"}, opts)
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## The bug this fixes

`scripts/setup-softhsm-runner.sh` in `sirosfoundation/trust-lists` — the documented way to set up a signing token — does this:

```bash
pkcs11-tool --keypairgen --label signing-key           # key K1, created in token
openssl req -new -x509 -newkey ec ... -out cert.pem    # key K2, generated and thrown away
pkcs11-tool --write-object cert.pem --type cert        # cert(K2) loaded into token
```

`openssl req -newkey` **generates its own key pair** for the certificate. The certificate loaded into the token describes K2 while the signing key is K1.

Nothing errors. Signing succeeds, the certificate looks plausible, and the resulting signature is unverifiable by anyone holding that certificate. The failure only ever surfaces in a relying party.

**This is live.** Every JWS on trust.siros.org fails verification against the certificate published beside it. Recovering the public key from the signatures gives one key common to all six lists — and it isn't the key in the published `root-signer.pem`:

```
recovered signing key x: 0xea880c3582521361c12ef95aea64e9a28535e2e044f8db24e429ca8e32d85305
published x5c cert    x: 0x8dda887dc5b5f12518f2f2b1c43e180b29f387bc5dcbea1215760498aa103ac4
```

The same pattern is in `publish.yml`'s dev fallback, and in this repo's own `GenerateAndImportTestCert` — which is why no existing test could have caught it.

## The fix

`dsig.SelfSignCertificate` takes the public key from the token's key pair and has the token produce the signature, so the two cannot disagree. It refuses to return a certificate that fails `CheckSignatureFrom` against itself, and when given a label it removes any prior certificate under that label first so a stale one can't be picked up instead.

```
tsl-tool -selfsign-cert \
  -pkcs11-uri "pkcs11:module=/usr/lib/softhsm/libsofthsm2.so;pin=…;token=trust-lists" \
  -key-label signing-key -key-id 01 -cert-label signing-cert \
  -subject "trust.siros.org Trust List Signer" -days 1095 \
  -output root-signer.pem
```

Putting it in `tsl-tool` means the signing host needs no extra tooling — no openssl pkcs11 provider or engine, which aren't installed there.

## Verification

End to end against a SoftHSM token built the broken way, using the real `lists/multipaz.org`:

```
BEFORE   INVALID  out/multipaz.org.json.jws
         (reproduces production exactly)
AFTER    VALID    out/multipaz.org.json.jws
```

Also checked the reissued cert's public key is byte-identical to the token's key, and that x5c matches the emitted `root-signer.pem` (`ec14f5cb…` both).

Full suite green with `-tags softhsm`, 0 failures.

## Note for reviewers

The test lives in `test/selfsign` for process isolation. The PKCS#11 module can only be initialized once per process, and `pkg/dsig`'s other tests initialize it against a token directory they then delete — leaving any later `crypto11.Configure` in that binary failing with `CKR_GENERAL_ERROR`. `pkg/jws` and `pkg/pipeline` get away with their SoftHSM tests for the same reason: separate package, separate process.

The test asserts the fixture **starts out mismatched** before asserting the fix, so it can't pass vacuously.

Follow-up in trust-lists will fix the setup script and reissue the live certificate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)